### PR TITLE
add extra dimension to a 3D array

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -36,7 +36,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
       - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2d/6a/885bc91484e1aa8f618f6f0228d76d0e67000b0fdd6090673b777e311913/asciitree-0.3.3.tar.gz
       - pypi: https://files.pythonhosted.org/packages/91/48/08b2382e739236aa3360b7976360ba3e0c043b6234e25951c18c1eb6fa06/bokeh-3.7.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/e8/64c37fadfc2816a7701fa8a6ed8d87327c7d54eacfbfb6edab14a2f2be75/cloudpickle-3.1.1-py3-none-any.whl
@@ -45,15 +44,16 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/57/77/606f138bf70b14865842b3ec9a58dc1ba97153f466e5876fe4ced980f91f/dask_jobqueue-0.9.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6e/c6/ac0b6c1e2d138f1002bcf799d330bd6d85084fece321e662a14223794041/Deprecated-1.2.18-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e8/90/82171cc7fe1c6d10bac57587c7ac012be80412ad06ef8c4952c5f067f869/distributed-2024.12.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/25/9a/fb3ba5497496cccc85be0d8deda38e15e33cc267d4f590c7118492cf8edc/eval_type_backport-0.1.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/51/ac/e5d886f892666d2d1e5cb8c1a41146e1d79ae8896477b1153a21711d3b44/fasteners-0.20-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/cd/c883e1a7c447479d6e13985565080e3fea88ab5a107c21684c813dba1875/flexcache-0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/5e/3be305568fe5f34448807976dc82fc151d76c3e0e03958f34770286278c1/flexparser-0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/e0/014d5d9d7a4564cf1c40b5039bc882db69fd881111e03ab3657ac0b218e2/fsspec-2025.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a9/02/2c0ec54c6e0746b7d5317de0bddce918d233476cd6f543e50ff4d378ca74/imagecodecs-2024.12.30-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f3/f0/89e7aadfb3749d0f52234a0c8c7867877876e0a20b60e2188e9850794c17/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/3a/cb/28ce52eb94390dda42599c98ea0204d74799e4d8047a0eb559b6fd648056/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/6f/cb/3f4ee8233f30c7926f1ed4885ff32b79ec7ce3210370f43e1cb2b385bed6/mrcfile-1.5.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4d/ec/fd869e2567cc9c01278a736cfd1697941ba0d4b81a43e0aa2e8d71dab208/msgpack-1.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a8/01/824fff6789ce92a53242d24b6f5f3a982df2f610c51020f934bf878d2a99/narwhals-2.1.2-py3-none-any.whl
@@ -68,7 +68,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/bf/b9/b0eb3f3cbcb734d930fdf839431606844a825b23eaf9a6ab371edac8162c/psutil-7.0.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/6a/c0/ec2b1c8712ca690e5d61979dee872603e92b8a32f94cc1b72d53beab008a/pydantic-2.11.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f9/41/4b043778cf9c4285d59742281a769eac371b9e47e35f98ad321349cc5d61/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/ef/c4/a21a21e34655052fcf5f5bcfa2d7c8795c6f38bc1aa1ee110754a16d5151/pydantic_zarr-0.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c7/05/04af0ca9c5747c95591a549509ebbb0a986155015de59f1e4c984e3af9ab/pydantic_zarr-0.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b9/2b/614b4752f2e127db5cc206abc23a8c19678e92b23c3db30fc86ab731d3bd/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -76,6 +76,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/44/aa5c8b10b2cce7a053018e0d132bd58e27527a0243c4985383d5b6fd93e9/tblib-3.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/8a/590bb60a190d414abd2f83dd5b5148722d0c5d310a73e21b7a60ab98cf00/tensorstore-0.1.82-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/6e/be/10d23cfd4078fbec6aba768a357eff9e70c0b6d2a07398425985c524ad2a/tifffile-2025.3.30-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e302c9d8ff4977f5026676e130d28dd7578132a457170c/toolz-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f9/41/fb15f06e33d7430ca89420283a8762a4e6b8025b800ea51796ab5e6d9559/tornado-6.5.2-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -86,7 +87,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e6/c8/0f8db9d9478de8d70cbcae2056588401e26168e269d6d9919bf2ecb01f78/xarray-2025.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/76/5c/c0bf6fbf1ebbd39e2adc98449d357e6fb7cdc13133aae53936e66590b8ae/xarray_multiscale-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/7d/b77455d7c7c51255b2992b429107fab811b2e36ceaf76da1e55a045dc568/xyzservices-2025.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ed/c9/142095e654c2b97133ff71df60979422717b29738b08bc8a1709a5d5e0d0/zarr-2.18.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/de/7c/ba8ca8cbe9dbef8e83a95fc208fed8e6686c98b4719aaa0aa7f3d31fe390/zarr-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
@@ -109,7 +110,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
       - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2d/6a/885bc91484e1aa8f618f6f0228d76d0e67000b0fdd6090673b777e311913/asciitree-0.3.3.tar.gz
       - pypi: https://files.pythonhosted.org/packages/91/48/08b2382e739236aa3360b7976360ba3e0c043b6234e25951c18c1eb6fa06/bokeh-3.7.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/e8/64c37fadfc2816a7701fa8a6ed8d87327c7d54eacfbfb6edab14a2f2be75/cloudpickle-3.1.1-py3-none-any.whl
@@ -118,15 +118,16 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/57/77/606f138bf70b14865842b3ec9a58dc1ba97153f466e5876fe4ced980f91f/dask_jobqueue-0.9.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6e/c6/ac0b6c1e2d138f1002bcf799d330bd6d85084fece321e662a14223794041/Deprecated-1.2.18-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e8/90/82171cc7fe1c6d10bac57587c7ac012be80412ad06ef8c4952c5f067f869/distributed-2024.12.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/25/9a/fb3ba5497496cccc85be0d8deda38e15e33cc267d4f590c7118492cf8edc/eval_type_backport-0.1.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/51/ac/e5d886f892666d2d1e5cb8c1a41146e1d79ae8896477b1153a21711d3b44/fasteners-0.20-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/cd/c883e1a7c447479d6e13985565080e3fea88ab5a107c21684c813dba1875/flexcache-0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/5e/3be305568fe5f34448807976dc82fc151d76c3e0e03958f34770286278c1/flexparser-0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/e0/014d5d9d7a4564cf1c40b5039bc882db69fd881111e03ab3657ac0b218e2/fsspec-2025.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/21/8e/58c0d5d86e2220e6a37befe7e6a94dd2f6006044b1a33edf1ff6d9f7e319/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/5f/22/f691b42e7a6418d55fefeede2c9db444c64e02f6f58c5eaf6eaf72e791e1/imagecodecs-2024.12.30-cp312-cp312-macosx_10_14_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/22/09/d1f21434c97fc42f09d290cbb6350d44eb12f09cc62c9476effdb33a18aa/MarkupSafe-3.0.2-cp312-cp312-macosx_10_13_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/a8/b8/3c70881695e056f8a32f8b941126cf78775d9a4d7feba8abcb52cb7b04f2/ml_dtypes-0.5.4-cp312-cp312-macosx_10_13_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/6f/cb/3f4ee8233f30c7926f1ed4885ff32b79ec7ce3210370f43e1cb2b385bed6/mrcfile-1.5.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e3/26/389b9c593eda2b8551b2e7126ad3a06af6f9b44274eb3a4f054d48ff7e47/msgpack-1.1.1-cp312-cp312-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/dd/54/1ecca75e51d7da8ca53d1ffa8636ef9077a6eaa31f43ade71360b3e6449a/narwhals-2.2.0-py3-none-any.whl
@@ -141,7 +142,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ed/e6/2d26234410f8b8abdbf891c9da62bee396583f713fb9f3325a4760875d22/psutil-7.0.0-cp36-abi3-macosx_10_9_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/6a/c0/ec2b1c8712ca690e5d61979dee872603e92b8a32f94cc1b72d53beab008a/pydantic-2.11.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/18/8a/2b41c97f554ec8c71f2a8a5f85cb56a8b0956addfe8b0efb5b3d77e8bdc3/pydantic_core-2.33.2-cp312-cp312-macosx_10_12_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/ef/c4/a21a21e34655052fcf5f5bcfa2d7c8795c6f38bc1aa1ee110754a16d5151/pydantic_zarr-0.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c7/05/04af0ca9c5747c95591a549509ebbb0a986155015de59f1e4c984e3af9ab/pydantic_zarr-0.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/86/0c/c581167fc46d6d6d7ddcfb8c843a4de25bdd27e4466938109ca68492292c/PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl
@@ -149,6 +150,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/44/aa5c8b10b2cce7a053018e0d132bd58e27527a0243c4985383d5b6fd93e9/tblib-3.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0d/c3/5ab0b99487b2596bdc0ebd3a569e50415949a63bad90b18e6476de91a7bb/tensorstore-0.1.82-cp312-cp312-macosx_10_14_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/6e/be/10d23cfd4078fbec6aba768a357eff9e70c0b6d2a07398425985c524ad2a/tifffile-2025.3.30-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e302c9d8ff4977f5026676e130d28dd7578132a457170c/toolz-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f2/b5/9b575a0ed3e50b00c40b08cbce82eb618229091d09f6d14bce80fc01cb0b/tornado-6.5.2-cp39-abi3-macosx_10_9_x86_64.whl
@@ -159,7 +161,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e6/c8/0f8db9d9478de8d70cbcae2056588401e26168e269d6d9919bf2ecb01f78/xarray-2025.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/76/5c/c0bf6fbf1ebbd39e2adc98449d357e6fb7cdc13133aae53936e66590b8ae/xarray_multiscale-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/7d/b77455d7c7c51255b2992b429107fab811b2e36ceaf76da1e55a045dc568/xyzservices-2025.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5e/d8/9ffd8c237b3559945bb52103cf0eed64ea098f7b7f573f8d2962ef27b4b2/zarr-2.18.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/de/7c/ba8ca8cbe9dbef8e83a95fc208fed8e6686c98b4719aaa0aa7f3d31fe390/zarr-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
@@ -183,7 +185,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
       - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2d/6a/885bc91484e1aa8f618f6f0228d76d0e67000b0fdd6090673b777e311913/asciitree-0.3.3.tar.gz
       - pypi: https://files.pythonhosted.org/packages/91/48/08b2382e739236aa3360b7976360ba3e0c043b6234e25951c18c1eb6fa06/bokeh-3.7.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/e8/64c37fadfc2816a7701fa8a6ed8d87327c7d54eacfbfb6edab14a2f2be75/cloudpickle-3.1.1-py3-none-any.whl
@@ -192,15 +193,16 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/57/77/606f138bf70b14865842b3ec9a58dc1ba97153f466e5876fe4ced980f91f/dask_jobqueue-0.9.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6e/c6/ac0b6c1e2d138f1002bcf799d330bd6d85084fece321e662a14223794041/Deprecated-1.2.18-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e8/90/82171cc7fe1c6d10bac57587c7ac012be80412ad06ef8c4952c5f067f869/distributed-2024.12.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/25/9a/fb3ba5497496cccc85be0d8deda38e15e33cc267d4f590c7118492cf8edc/eval_type_backport-0.1.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/51/ac/e5d886f892666d2d1e5cb8c1a41146e1d79ae8896477b1153a21711d3b44/fasteners-0.20-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/cd/c883e1a7c447479d6e13985565080e3fea88ab5a107c21684c813dba1875/flexcache-0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/5e/3be305568fe5f34448807976dc82fc151d76c3e0e03958f34770286278c1/flexparser-0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/e0/014d5d9d7a4564cf1c40b5039bc882db69fd881111e03ab3657ac0b218e2/fsspec-2025.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e9/5f/7307325b1198b59324c0fa9807cafb551afb65e831699f2ce211ad5c8240/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/a8/65/c66cc78e3d0c0aca017957d97759babf64d385454aa6dc8d5395665c3f6b/imagecodecs-2024.12.30-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6b/b0/18f76bba336fa5aecf79d45dcd6c806c280ec44538b3c13671d49099fdd0/MarkupSafe-3.0.2-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/a8/b8/3c70881695e056f8a32f8b941126cf78775d9a4d7feba8abcb52cb7b04f2/ml_dtypes-0.5.4-cp312-cp312-macosx_10_13_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/6f/cb/3f4ee8233f30c7926f1ed4885ff32b79ec7ce3210370f43e1cb2b385bed6/mrcfile-1.5.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ab/65/7d1de38c8a22cf8b1551469159d4b6cf49be2126adc2482de50976084d78/msgpack-1.1.1-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/dd/54/1ecca75e51d7da8ca53d1ffa8636ef9077a6eaa31f43ade71360b3e6449a/narwhals-2.2.0-py3-none-any.whl
@@ -215,7 +217,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/04/8b/30f930733afe425e3cbfc0e1468a30a18942350c1a8816acfade80c005c4/psutil-7.0.0-cp36-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/6a/c0/ec2b1c8712ca690e5d61979dee872603e92b8a32f94cc1b72d53beab008a/pydantic-2.11.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a1/02/6224312aacb3c8ecbaa959897af57181fb6cf3a3d7917fd44d0f2917e6f2/pydantic_core-2.33.2-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/ef/c4/a21a21e34655052fcf5f5bcfa2d7c8795c6f38bc1aa1ee110754a16d5151/pydantic_zarr-0.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c7/05/04af0ca9c5747c95591a549509ebbb0a986155015de59f1e4c984e3af9ab/pydantic_zarr-0.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/0c/38374f5bb272c051e2a69281d71cba6fdb983413e6758b84482905e29a5d/PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl
@@ -223,6 +225,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/44/aa5c8b10b2cce7a053018e0d132bd58e27527a0243c4985383d5b6fd93e9/tblib-3.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/aa/95/92b00a4b2e6192528a9c5bac9f53007acf4aa5d54943b9e114bedb72b2da/tensorstore-0.1.82-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/6e/be/10d23cfd4078fbec6aba768a357eff9e70c0b6d2a07398425985c524ad2a/tifffile-2025.3.30-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e302c9d8ff4977f5026676e130d28dd7578132a457170c/toolz-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f6/48/6a7529df2c9cc12efd2e8f5dd219516184d703b34c06786809670df5b3bd/tornado-6.5.2-cp39-abi3-macosx_10_9_universal2.whl
@@ -233,7 +236,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e6/c8/0f8db9d9478de8d70cbcae2056588401e26168e269d6d9919bf2ecb01f78/xarray-2025.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/76/5c/c0bf6fbf1ebbd39e2adc98449d357e6fb7cdc13133aae53936e66590b8ae/xarray_multiscale-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/7d/b77455d7c7c51255b2992b429107fab811b2e36ceaf76da1e55a045dc568/xyzservices-2025.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5e/d8/9ffd8c237b3559945bb52103cf0eed64ea098f7b7f573f8d2962ef27b4b2/zarr-2.18.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/de/7c/ba8ca8cbe9dbef8e83a95fc208fed8e6686c98b4719aaa0aa7f3d31fe390/zarr-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl
   test:
     channels:
@@ -277,7 +280,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
       - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2d/6a/885bc91484e1aa8f618f6f0228d76d0e67000b0fdd6090673b777e311913/asciitree-0.3.3.tar.gz
       - pypi: https://files.pythonhosted.org/packages/91/48/08b2382e739236aa3360b7976360ba3e0c043b6234e25951c18c1eb6fa06/bokeh-3.7.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/e8/64c37fadfc2816a7701fa8a6ed8d87327c7d54eacfbfb6edab14a2f2be75/cloudpickle-3.1.1-py3-none-any.whl
@@ -286,15 +288,16 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/57/77/606f138bf70b14865842b3ec9a58dc1ba97153f466e5876fe4ced980f91f/dask_jobqueue-0.9.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6e/c6/ac0b6c1e2d138f1002bcf799d330bd6d85084fece321e662a14223794041/Deprecated-1.2.18-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e8/90/82171cc7fe1c6d10bac57587c7ac012be80412ad06ef8c4952c5f067f869/distributed-2024.12.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/25/9a/fb3ba5497496cccc85be0d8deda38e15e33cc267d4f590c7118492cf8edc/eval_type_backport-0.1.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/51/ac/e5d886f892666d2d1e5cb8c1a41146e1d79ae8896477b1153a21711d3b44/fasteners-0.20-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/cd/c883e1a7c447479d6e13985565080e3fea88ab5a107c21684c813dba1875/flexcache-0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/5e/3be305568fe5f34448807976dc82fc151d76c3e0e03958f34770286278c1/flexparser-0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/e0/014d5d9d7a4564cf1c40b5039bc882db69fd881111e03ab3657ac0b218e2/fsspec-2025.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a9/02/2c0ec54c6e0746b7d5317de0bddce918d233476cd6f543e50ff4d378ca74/imagecodecs-2024.12.30-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f3/f0/89e7aadfb3749d0f52234a0c8c7867877876e0a20b60e2188e9850794c17/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/3a/cb/28ce52eb94390dda42599c98ea0204d74799e4d8047a0eb559b6fd648056/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/6f/cb/3f4ee8233f30c7926f1ed4885ff32b79ec7ce3210370f43e1cb2b385bed6/mrcfile-1.5.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4d/ec/fd869e2567cc9c01278a736cfd1697941ba0d4b81a43e0aa2e8d71dab208/msgpack-1.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a8/01/824fff6789ce92a53242d24b6f5f3a982df2f610c51020f934bf878d2a99/narwhals-2.1.2-py3-none-any.whl
@@ -309,7 +312,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/bf/b9/b0eb3f3cbcb734d930fdf839431606844a825b23eaf9a6ab371edac8162c/psutil-7.0.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/6a/c0/ec2b1c8712ca690e5d61979dee872603e92b8a32f94cc1b72d53beab008a/pydantic-2.11.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f9/41/4b043778cf9c4285d59742281a769eac371b9e47e35f98ad321349cc5d61/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/ef/c4/a21a21e34655052fcf5f5bcfa2d7c8795c6f38bc1aa1ee110754a16d5151/pydantic_zarr-0.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c7/05/04af0ca9c5747c95591a549509ebbb0a986155015de59f1e4c984e3af9ab/pydantic_zarr-0.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b9/2b/614b4752f2e127db5cc206abc23a8c19678e92b23c3db30fc86ab731d3bd/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -317,6 +320,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/44/aa5c8b10b2cce7a053018e0d132bd58e27527a0243c4985383d5b6fd93e9/tblib-3.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/8a/590bb60a190d414abd2f83dd5b5148722d0c5d310a73e21b7a60ab98cf00/tensorstore-0.1.82-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/6e/be/10d23cfd4078fbec6aba768a357eff9e70c0b6d2a07398425985c524ad2a/tifffile-2025.3.30-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e302c9d8ff4977f5026676e130d28dd7578132a457170c/toolz-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f9/41/fb15f06e33d7430ca89420283a8762a4e6b8025b800ea51796ab5e6d9559/tornado-6.5.2-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -327,7 +331,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e6/c8/0f8db9d9478de8d70cbcae2056588401e26168e269d6d9919bf2ecb01f78/xarray-2025.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/76/5c/c0bf6fbf1ebbd39e2adc98449d357e6fb7cdc13133aae53936e66590b8ae/xarray_multiscale-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/7d/b77455d7c7c51255b2992b429107fab811b2e36ceaf76da1e55a045dc568/xyzservices-2025.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ed/c9/142095e654c2b97133ff71df60979422717b29738b08bc8a1709a5d5e0d0/zarr-2.18.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/de/7c/ba8ca8cbe9dbef8e83a95fc208fed8e6686c98b4719aaa0aa7f3d31fe390/zarr-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
@@ -356,7 +360,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
       - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2d/6a/885bc91484e1aa8f618f6f0228d76d0e67000b0fdd6090673b777e311913/asciitree-0.3.3.tar.gz
       - pypi: https://files.pythonhosted.org/packages/91/48/08b2382e739236aa3360b7976360ba3e0c043b6234e25951c18c1eb6fa06/bokeh-3.7.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/e8/64c37fadfc2816a7701fa8a6ed8d87327c7d54eacfbfb6edab14a2f2be75/cloudpickle-3.1.1-py3-none-any.whl
@@ -365,15 +368,16 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/57/77/606f138bf70b14865842b3ec9a58dc1ba97153f466e5876fe4ced980f91f/dask_jobqueue-0.9.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6e/c6/ac0b6c1e2d138f1002bcf799d330bd6d85084fece321e662a14223794041/Deprecated-1.2.18-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e8/90/82171cc7fe1c6d10bac57587c7ac012be80412ad06ef8c4952c5f067f869/distributed-2024.12.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/25/9a/fb3ba5497496cccc85be0d8deda38e15e33cc267d4f590c7118492cf8edc/eval_type_backport-0.1.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/51/ac/e5d886f892666d2d1e5cb8c1a41146e1d79ae8896477b1153a21711d3b44/fasteners-0.20-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/cd/c883e1a7c447479d6e13985565080e3fea88ab5a107c21684c813dba1875/flexcache-0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/5e/3be305568fe5f34448807976dc82fc151d76c3e0e03958f34770286278c1/flexparser-0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/e0/014d5d9d7a4564cf1c40b5039bc882db69fd881111e03ab3657ac0b218e2/fsspec-2025.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/21/8e/58c0d5d86e2220e6a37befe7e6a94dd2f6006044b1a33edf1ff6d9f7e319/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/5f/22/f691b42e7a6418d55fefeede2c9db444c64e02f6f58c5eaf6eaf72e791e1/imagecodecs-2024.12.30-cp312-cp312-macosx_10_14_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/22/09/d1f21434c97fc42f09d290cbb6350d44eb12f09cc62c9476effdb33a18aa/MarkupSafe-3.0.2-cp312-cp312-macosx_10_13_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/a8/b8/3c70881695e056f8a32f8b941126cf78775d9a4d7feba8abcb52cb7b04f2/ml_dtypes-0.5.4-cp312-cp312-macosx_10_13_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/6f/cb/3f4ee8233f30c7926f1ed4885ff32b79ec7ce3210370f43e1cb2b385bed6/mrcfile-1.5.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e3/26/389b9c593eda2b8551b2e7126ad3a06af6f9b44274eb3a4f054d48ff7e47/msgpack-1.1.1-cp312-cp312-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/dd/54/1ecca75e51d7da8ca53d1ffa8636ef9077a6eaa31f43ade71360b3e6449a/narwhals-2.2.0-py3-none-any.whl
@@ -388,7 +392,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ed/e6/2d26234410f8b8abdbf891c9da62bee396583f713fb9f3325a4760875d22/psutil-7.0.0-cp36-abi3-macosx_10_9_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/6a/c0/ec2b1c8712ca690e5d61979dee872603e92b8a32f94cc1b72d53beab008a/pydantic-2.11.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/18/8a/2b41c97f554ec8c71f2a8a5f85cb56a8b0956addfe8b0efb5b3d77e8bdc3/pydantic_core-2.33.2-cp312-cp312-macosx_10_12_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/ef/c4/a21a21e34655052fcf5f5bcfa2d7c8795c6f38bc1aa1ee110754a16d5151/pydantic_zarr-0.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c7/05/04af0ca9c5747c95591a549509ebbb0a986155015de59f1e4c984e3af9ab/pydantic_zarr-0.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/86/0c/c581167fc46d6d6d7ddcfb8c843a4de25bdd27e4466938109ca68492292c/PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl
@@ -396,6 +400,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/44/aa5c8b10b2cce7a053018e0d132bd58e27527a0243c4985383d5b6fd93e9/tblib-3.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0d/c3/5ab0b99487b2596bdc0ebd3a569e50415949a63bad90b18e6476de91a7bb/tensorstore-0.1.82-cp312-cp312-macosx_10_14_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/6e/be/10d23cfd4078fbec6aba768a357eff9e70c0b6d2a07398425985c524ad2a/tifffile-2025.3.30-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e302c9d8ff4977f5026676e130d28dd7578132a457170c/toolz-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f2/b5/9b575a0ed3e50b00c40b08cbce82eb618229091d09f6d14bce80fc01cb0b/tornado-6.5.2-cp39-abi3-macosx_10_9_x86_64.whl
@@ -406,7 +411,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e6/c8/0f8db9d9478de8d70cbcae2056588401e26168e269d6d9919bf2ecb01f78/xarray-2025.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/76/5c/c0bf6fbf1ebbd39e2adc98449d357e6fb7cdc13133aae53936e66590b8ae/xarray_multiscale-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/7d/b77455d7c7c51255b2992b429107fab811b2e36ceaf76da1e55a045dc568/xyzservices-2025.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5e/d8/9ffd8c237b3559945bb52103cf0eed64ea098f7b7f573f8d2962ef27b4b2/zarr-2.18.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/de/7c/ba8ca8cbe9dbef8e83a95fc208fed8e6686c98b4719aaa0aa7f3d31fe390/zarr-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
@@ -436,7 +441,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
       - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2d/6a/885bc91484e1aa8f618f6f0228d76d0e67000b0fdd6090673b777e311913/asciitree-0.3.3.tar.gz
       - pypi: https://files.pythonhosted.org/packages/91/48/08b2382e739236aa3360b7976360ba3e0c043b6234e25951c18c1eb6fa06/bokeh-3.7.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/e8/64c37fadfc2816a7701fa8a6ed8d87327c7d54eacfbfb6edab14a2f2be75/cloudpickle-3.1.1-py3-none-any.whl
@@ -445,15 +449,16 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/57/77/606f138bf70b14865842b3ec9a58dc1ba97153f466e5876fe4ced980f91f/dask_jobqueue-0.9.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6e/c6/ac0b6c1e2d138f1002bcf799d330bd6d85084fece321e662a14223794041/Deprecated-1.2.18-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e8/90/82171cc7fe1c6d10bac57587c7ac012be80412ad06ef8c4952c5f067f869/distributed-2024.12.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/25/9a/fb3ba5497496cccc85be0d8deda38e15e33cc267d4f590c7118492cf8edc/eval_type_backport-0.1.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/51/ac/e5d886f892666d2d1e5cb8c1a41146e1d79ae8896477b1153a21711d3b44/fasteners-0.20-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/cd/c883e1a7c447479d6e13985565080e3fea88ab5a107c21684c813dba1875/flexcache-0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/5e/3be305568fe5f34448807976dc82fc151d76c3e0e03958f34770286278c1/flexparser-0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/e0/014d5d9d7a4564cf1c40b5039bc882db69fd881111e03ab3657ac0b218e2/fsspec-2025.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e9/5f/7307325b1198b59324c0fa9807cafb551afb65e831699f2ce211ad5c8240/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/a8/65/c66cc78e3d0c0aca017957d97759babf64d385454aa6dc8d5395665c3f6b/imagecodecs-2024.12.30-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6b/b0/18f76bba336fa5aecf79d45dcd6c806c280ec44538b3c13671d49099fdd0/MarkupSafe-3.0.2-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/a8/b8/3c70881695e056f8a32f8b941126cf78775d9a4d7feba8abcb52cb7b04f2/ml_dtypes-0.5.4-cp312-cp312-macosx_10_13_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/6f/cb/3f4ee8233f30c7926f1ed4885ff32b79ec7ce3210370f43e1cb2b385bed6/mrcfile-1.5.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ab/65/7d1de38c8a22cf8b1551469159d4b6cf49be2126adc2482de50976084d78/msgpack-1.1.1-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/dd/54/1ecca75e51d7da8ca53d1ffa8636ef9077a6eaa31f43ade71360b3e6449a/narwhals-2.2.0-py3-none-any.whl
@@ -468,7 +473,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/04/8b/30f930733afe425e3cbfc0e1468a30a18942350c1a8816acfade80c005c4/psutil-7.0.0-cp36-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/6a/c0/ec2b1c8712ca690e5d61979dee872603e92b8a32f94cc1b72d53beab008a/pydantic-2.11.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a1/02/6224312aacb3c8ecbaa959897af57181fb6cf3a3d7917fd44d0f2917e6f2/pydantic_core-2.33.2-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/ef/c4/a21a21e34655052fcf5f5bcfa2d7c8795c6f38bc1aa1ee110754a16d5151/pydantic_zarr-0.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c7/05/04af0ca9c5747c95591a549509ebbb0a986155015de59f1e4c984e3af9ab/pydantic_zarr-0.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/0c/38374f5bb272c051e2a69281d71cba6fdb983413e6758b84482905e29a5d/PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl
@@ -476,6 +481,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/44/aa5c8b10b2cce7a053018e0d132bd58e27527a0243c4985383d5b6fd93e9/tblib-3.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/aa/95/92b00a4b2e6192528a9c5bac9f53007acf4aa5d54943b9e114bedb72b2da/tensorstore-0.1.82-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/6e/be/10d23cfd4078fbec6aba768a357eff9e70c0b6d2a07398425985c524ad2a/tifffile-2025.3.30-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e302c9d8ff4977f5026676e130d28dd7578132a457170c/toolz-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f6/48/6a7529df2c9cc12efd2e8f5dd219516184d703b34c06786809670df5b3bd/tornado-6.5.2-cp39-abi3-macosx_10_9_universal2.whl
@@ -486,7 +492,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e6/c8/0f8db9d9478de8d70cbcae2056588401e26168e269d6d9919bf2ecb01f78/xarray-2025.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/76/5c/c0bf6fbf1ebbd39e2adc98449d357e6fb7cdc13133aae53936e66590b8ae/xarray_multiscale-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/7d/b77455d7c7c51255b2992b429107fab811b2e36ceaf76da1e55a045dc568/xyzservices-2025.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5e/d8/9ffd8c237b3559945bb52103cf0eed64ea098f7b7f573f8d2962ef27b4b2/zarr-2.18.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/de/7c/ba8ca8cbe9dbef8e83a95fc208fed8e6686c98b4719aaa0aa7f3d31fe390/zarr-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -517,10 +523,6 @@ packages:
   requires_dist:
   - typing-extensions>=4.0.0 ; python_full_version < '3.9'
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/2d/6a/885bc91484e1aa8f618f6f0228d76d0e67000b0fdd6090673b777e311913/asciitree-0.3.3.tar.gz
-  name: asciitree
-  version: 0.3.3
-  sha256: 4aa4b9b649f85e3fcb343363d97564aa1fb62e249677f2e18a96765145cc0f6e
 - pypi: https://files.pythonhosted.org/packages/91/48/08b2382e739236aa3360b7976360ba3e0c043b6234e25951c18c1eb6fa06/bokeh-3.7.3-py3-none-any.whl
   name: bokeh
   version: 3.7.3
@@ -750,13 +752,19 @@ packages:
   - urllib3>=1.26.5
   - zict>=3.0.0
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/25/9a/fb3ba5497496cccc85be0d8deda38e15e33cc267d4f590c7118492cf8edc/eval_type_backport-0.1.3-py3-none-any.whl
-  name: eval-type-backport
-  version: 0.1.3
-  sha256: 519d2a993b3da286df9f90e17f503f66435106ad870cf26620c5720e2158ddf2
+- pypi: https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl
+  name: donfig
+  version: 0.8.1.post1
+  sha256: 2a3175ce74a06109ff9307d90a230f81215cbac9a751f4d1c6194644b8204f9d
   requires_dist:
-  - pytest ; extra == 'tests'
-  requires_python: '>=3.7'
+  - pyyaml
+  - sphinx>=4.0.0 ; extra == 'docs'
+  - numpydoc ; extra == 'docs'
+  - pytest ; extra == 'docs'
+  - cloudpickle ; extra == 'docs'
+  - pytest ; extra == 'test'
+  - cloudpickle ; extra == 'test'
+  requires_python: '>=3.8'
 - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
   sha256: ce61f4f99401a4bd455b89909153b40b9c823276aefcbb06f2044618696009ca
   md5: 72e42d28960d875c7654614f8b50939a
@@ -768,11 +776,6 @@ packages:
   - pkg:pypi/exceptiongroup?source=hash-mapping
   size: 21284
   timestamp: 1746947398083
-- pypi: https://files.pythonhosted.org/packages/51/ac/e5d886f892666d2d1e5cb8c1a41146e1d79ae8896477b1153a21711d3b44/fasteners-0.20-py3-none-any.whl
-  name: fasteners
-  version: '0.20'
-  sha256: 9422c40d1e350e4259f509fb2e608d6bc43c0136f79a00db1b49046029d0b3b7
-  requires_python: '>=3.6'
 - pypi: https://files.pythonhosted.org/packages/27/cd/c883e1a7c447479d6e13985565080e3fea88ab5a107c21684c813dba1875/flexcache-0.3-py3-none-any.whl
   name: flexcache
   version: '0.3'
@@ -901,6 +904,21 @@ packages:
   - zarr ; extra == 'test-full'
   - zstandard ; python_full_version < '3.14' and extra == 'test-full'
   - tqdm ; extra == 'tqdm'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/21/8e/58c0d5d86e2220e6a37befe7e6a94dd2f6006044b1a33edf1ff6d9f7e319/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_x86_64.whl
+  name: google-crc32c
+  version: 1.8.0
+  sha256: 2a3dc3318507de089c5384cc74d54318401410f82aa65b2d9cdde9d297aca7cb
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl
+  name: google-crc32c
+  version: 1.8.0
+  sha256: 14f87e04d613dfa218d6135e81b78272c3b904e2a7053b841481b38a7d901411
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/e9/5f/7307325b1198b59324c0fa9807cafb551afb65e831699f2ce211ad5c8240/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_arm64.whl
+  name: google-crc32c
+  version: 1.8.0
+  sha256: 4b8286b659c1335172e39563ab0a768b8015e88e08329fa5321f774275fc3113
   requires_python: '>=3.9'
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
   sha256: 9ba12c93406f3df5ab0a43db8a4b4ef67a5871dfd401010fbe29b218b2cbe620
@@ -1269,6 +1287,38 @@ packages:
   name: markupsafe
   version: 3.0.2
   sha256: e17c96c14e19278594aa4841ec148115f9c7615a47382ecb6b82bd8fea3ab0c8
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/3a/cb/28ce52eb94390dda42599c98ea0204d74799e4d8047a0eb559b6fd648056/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+  name: ml-dtypes
+  version: 0.5.4
+  sha256: 9ad459e99793fa6e13bd5b7e6792c8f9190b4e5a1b45c63aba14a4d0a7f1d5ff
+  requires_dist:
+  - numpy>=1.21
+  - numpy>=1.21.2 ; python_full_version >= '3.10'
+  - numpy>=1.23.3 ; python_full_version >= '3.11'
+  - numpy>=1.26.0 ; python_full_version >= '3.12'
+  - numpy>=2.1.0 ; python_full_version >= '3.13'
+  - absl-py ; extra == 'dev'
+  - pytest ; extra == 'dev'
+  - pytest-xdist ; extra == 'dev'
+  - pylint>=2.6.0 ; extra == 'dev'
+  - pyink ; extra == 'dev'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/a8/b8/3c70881695e056f8a32f8b941126cf78775d9a4d7feba8abcb52cb7b04f2/ml_dtypes-0.5.4-cp312-cp312-macosx_10_13_universal2.whl
+  name: ml-dtypes
+  version: 0.5.4
+  sha256: a174837a64f5b16cab6f368171a1a03a27936b31699d167684073ff1c4237dac
+  requires_dist:
+  - numpy>=1.21
+  - numpy>=1.21.2 ; python_full_version >= '3.10'
+  - numpy>=1.23.3 ; python_full_version >= '3.11'
+  - numpy>=1.26.0 ; python_full_version >= '3.12'
+  - numpy>=2.1.0 ; python_full_version >= '3.13'
+  - absl-py ; extra == 'dev'
+  - pytest ; extra == 'dev'
+  - pytest-xdist ; extra == 'dev'
+  - pylint>=2.6.0 ; extra == 'dev'
+  - pyink ; extra == 'dev'
   requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/6f/cb/3f4ee8233f30c7926f1ed4885ff32b79ec7ce3210370f43e1cb2b385bed6/mrcfile-1.5.4-py2.py3-none-any.whl
   name: mrcfile
@@ -2106,16 +2156,35 @@ packages:
   requires_dist:
   - typing-extensions>=4.6.0,!=4.7.0
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/ef/c4/a21a21e34655052fcf5f5bcfa2d7c8795c6f38bc1aa1ee110754a16d5151/pydantic_zarr-0.7.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/c7/05/04af0ca9c5747c95591a549509ebbb0a986155015de59f1e4c984e3af9ab/pydantic_zarr-0.10.0-py3-none-any.whl
   name: pydantic-zarr
-  version: 0.7.0
-  sha256: 8fafb481e7dfa77b3202b91937b777b266387d03e9f6dad5b7eaeca3ae4b5baf
+  version: 0.10.0
+  sha256: d15769dab43346b070051fdf6e83509d7f55259dd00c6d12be2400935117e230
   requires_dist:
-  - eval-type-backport>=0.1.3,<0.2.0
-  - pydantic>=2.0.0,<3.0.0
-  - typing-extensions>=4.7.1,<5.0.0 ; python_full_version < '3.12'
-  - zarr>=2.14.2,<3.0.0
-  requires_python: '>=3.9,<4.0'
+  - numpy>=2.0.0
+  - packaging>=21.0
+  - pydantic>2.0.0
+  - mkdocs-material ; extra == 'docs'
+  - mkdocstrings[python] ; extra == 'docs'
+  - pydantic==2.12.* ; extra == 'docs'
+  - pytest-examples ; extra == 'docs'
+  - towncrier ; extra == 'docs'
+  - zarr>=3.1.0 ; extra == 'docs'
+  - coverage ; extra == 'test'
+  - dask==2025.11.0 ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - pytest-examples ; extra == 'test'
+  - pytest<8.4 ; extra == 'test'
+  - xarray==2025.10.0 ; extra == 'test'
+  - zarr>=3.0.0 ; extra == 'test'
+  - coverage ; extra == 'test-base'
+  - dask==2025.11.0 ; extra == 'test-base'
+  - pytest-cov ; extra == 'test-base'
+  - pytest-examples ; extra == 'test-base'
+  - pytest<8.4 ; extra == 'test-base'
+  - xarray==2025.10.0 ; extra == 'test-base'
+  - zarr>=3.0.0 ; extra == 'zarr'
+  requires_python: '>=3.12'
 - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
   sha256: 5577623b9f6685ece2697c6eb7511b4c9ac5fb607c9babc2646c811b428fd46a
   md5: 6b6ece66ebcae2d5f326c77ef2c5a066
@@ -2432,6 +2501,30 @@ packages:
   version: 3.1.0
   sha256: 670bb4582578134b3d81a84afa1b016128b429f3d48e6cbbaecc9d15675e984e
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/0d/c3/5ab0b99487b2596bdc0ebd3a569e50415949a63bad90b18e6476de91a7bb/tensorstore-0.1.82-cp312-cp312-macosx_10_14_x86_64.whl
+  name: tensorstore
+  version: 0.1.82
+  sha256: f0ac091bd47ea6f051fe11230ad2642c254b46a8fabdd5184b0600556b5529ed
+  requires_dist:
+  - numpy>=1.22.0
+  - ml-dtypes>=0.5.0
+  requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/aa/95/92b00a4b2e6192528a9c5bac9f53007acf4aa5d54943b9e114bedb72b2da/tensorstore-0.1.82-cp312-cp312-macosx_11_0_arm64.whl
+  name: tensorstore
+  version: 0.1.82
+  sha256: 8cae7d0c9b2fa0653f90b147daaf9ed04664cab7d297b9772efcfa088da26cab
+  requires_dist:
+  - numpy>=1.22.0
+  - ml-dtypes>=0.5.0
+  requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/f9/8a/590bb60a190d414abd2f83dd5b5148722d0c5d310a73e21b7a60ab98cf00/tensorstore-0.1.82-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+  name: tensorstore
+  version: 0.1.82
+  sha256: d4182300d8ffa172e961e79c6bd89e38ce6bc5cd3abf1a7dacb22c2396ce40b7
+  requires_dist:
+  - numpy>=1.22.0
+  - ml-dtypes>=0.5.0
+  requires_python: '>=3.11'
 - pypi: https://files.pythonhosted.org/packages/6e/be/10d23cfd4078fbec6aba768a357eff9e70c0b6d2a07398425985c524ad2a/tifffile-2025.3.30-py3-none-any.whl
   name: tifffile
   version: 2025.3.30
@@ -2662,48 +2755,22 @@ packages:
   version: 2025.4.0
   sha256: 8d4db9a59213ccb4ce1cf70210584f30b10795bff47627cdfb862b39ff6e10c9
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/ed/c9/142095e654c2b97133ff71df60979422717b29738b08bc8a1709a5d5e0d0/zarr-2.18.3-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/de/7c/ba8ca8cbe9dbef8e83a95fc208fed8e6686c98b4719aaa0aa7f3d31fe390/zarr-3.1.6-py3-none-any.whl
   name: zarr
-  version: 2.18.3
-  sha256: b1f7dfd2496f436745cdd4c7bcf8d3b4bc1dceef5fdd0d589c87130d842496dd
+  version: 3.1.6
+  sha256: b5a82c5079d1c3d4ee8f06746fa3b9a98a7d804300fa3f4be154362a33e1207e
   requires_dist:
-  - asciitree
-  - numpy>=1.24
-  - numcodecs>=0.10.0
-  - fasteners ; sys_platform != 'emscripten'
-  - sphinx ; extra == 'docs'
-  - sphinx-automodapi ; extra == 'docs'
-  - sphinx-design ; extra == 'docs'
-  - sphinx-issues ; extra == 'docs'
-  - sphinx-copybutton ; extra == 'docs'
-  - pydata-sphinx-theme ; extra == 'docs'
-  - numpydoc ; extra == 'docs'
-  - numcodecs[msgpack] ; extra == 'docs'
-  - notebook ; extra == 'jupyter'
-  - ipytree>=0.2.2 ; extra == 'jupyter'
-  - ipywidgets>=8.0.0 ; extra == 'jupyter'
-  requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/5e/d8/9ffd8c237b3559945bb52103cf0eed64ea098f7b7f573f8d2962ef27b4b2/zarr-2.18.7-py3-none-any.whl
-  name: zarr
-  version: 2.18.7
-  sha256: ac3dc4033e9ae4e9d7b5e27c97ea3eaf1003cc0a07f010bd83d5134bf8c4b223
-  requires_dist:
-  - asciitree
-  - numpy>=1.24
-  - fasteners ; sys_platform != 'emscripten'
-  - numcodecs>=0.10.0,!=0.14.0,!=0.14.1,<0.16
-  - notebook ; extra == 'jupyter'
-  - ipytree>=0.2.2 ; extra == 'jupyter'
-  - ipywidgets>=8.0.0 ; extra == 'jupyter'
-  - sphinx ; extra == 'docs'
-  - sphinx-automodapi ; extra == 'docs'
-  - sphinx-design ; extra == 'docs'
-  - sphinx-issues ; extra == 'docs'
-  - sphinx-copybutton ; extra == 'docs'
-  - pydata-sphinx-theme ; extra == 'docs'
-  - numpydoc ; extra == 'docs'
-  - numcodecs[msgpack]!=0.14.0,!=0.14.1,<0.16 ; extra == 'docs'
-  - pytest-doctestplus ; extra == 'docs'
+  - donfig>=0.8
+  - google-crc32c>=1.5
+  - numcodecs>=0.14
+  - numpy>=2.0
+  - packaging>=22.0
+  - typing-extensions>=4.12
+  - typer ; extra == 'cli'
+  - cupy-cuda12x ; extra == 'gpu'
+  - universal-pathlib ; extra == 'optional'
+  - fsspec>=2023.10.0 ; extra == 'remote'
+  - obstore>=0.5.1 ; extra == 'remote'
   requires_python: '>=3.11'
 - pypi: https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl
   name: zict

--- a/src/zarrify/formats/mrc.py
+++ b/src/zarrify/formats/mrc.py
@@ -45,7 +45,7 @@ class Mrc3D(Volume):
         self.shape = np.squeeze(self.memmap.data.shape)
         self.dtype = self.memmap.data.dtype
 
-    def write_to_zarr(self, dst_spec: dict, client: Client) -> None:
+    def write_to_zarr(self, dst_spec: dict, client: Client, expand_dims: bool = False) -> None:
         """Read the MRC file in chunks and write each chunk to a zarr3 array via TensorStore.
 
         Chunks that are entirely zero are skipped to avoid unnecessary writes.
@@ -57,6 +57,9 @@ class Mrc3D(Volume):
             by :func:`~zarrify.utils.ts_utils.zarr3_spec`.
         client:
             Dask distributed client used to parallelise chunk writes.
+        expand_dims:
+            When True, the destination array has a leading size-1 channel
+            dimension; the leading slice is stripped when reading the source.
         """
         logging.basicConfig(
             level=logging.INFO,
@@ -78,7 +81,7 @@ class Mrc3D(Volume):
         for idx, part in enumerate(out_slices_partitioned):
             logging.info(f"{idx + 1} / {len(out_slices_partitioned)}")
             start = time.time()
-            fut = client.map(lambda v: save_chunk(src_path, dst_spec, v), part)
+            fut = client.map(lambda v: save_chunk(src_path, dst_spec, v, expand_dims), part)
             logging.info(
                 f"Submitted {len(part)} tasks to the scheduler in {time.time() - start:.2f}s"
             )
@@ -86,7 +89,8 @@ class Mrc3D(Volume):
             logging.info(f"Completed {len(part)} tasks in {time.time() - start:.2f}s")
 
 
-def save_chunk(src_path: str, dst_spec: dict, chunk_slice: Tuple[slice, ...]) -> None:
+def save_chunk(src_path: str, dst_spec: dict, chunk_slice: Tuple[slice, ...],
+               expand_dims: bool = False) -> None:
     """Copy one chunk from an MRC file into a zarr3 TensorStore array.
 
     Chunks that are entirely zero are skipped to avoid unnecessary I/O.
@@ -98,10 +102,14 @@ def save_chunk(src_path: str, dst_spec: dict, chunk_slice: Tuple[slice, ...]) ->
     dst_spec:
         TensorStore zarr3 spec dict for the destination array.
     chunk_slice:
-        The slice tuple identifying the chunk region to copy.
+        The slice tuple identifying the chunk region in the destination array.
+    expand_dims:
+        When True, strip the leading slice when reading the source (which has
+        no channel dimension) and prepend np.newaxis before writing.
     """
     mrc_file = mrcfile.mmap(src_path, mode="r")
-    data = mrc_file.data[chunk_slice]
+    src_slice = chunk_slice[1:] if expand_dims else chunk_slice
+    data = mrc_file.data[src_slice]
     if not (data == 0).all():
         dest_arr = open_ts(dst_spec)
-        dest_arr[chunk_slice].write(data).result()
+        dest_arr[chunk_slice].write(data[np.newaxis] if expand_dims else data).result()

--- a/src/zarrify/formats/n5.py
+++ b/src/zarrify/formats/n5.py
@@ -216,25 +216,27 @@ class N5Group(Volume):
 
         return z_attrs
 
-    def normalize_to_omengff(self, zgroup: zarr.Group) -> None:
+    def normalize_to_omengff(self, zgroup: zarr.Group, expand_dims: bool = False) -> None:
         """Recursively convert N5 metadata to OME-NGFF multiscales attributes.
 
         Parameters
         ----------
         zgroup:
             Root zarr group of the output zarr store.
+        expand_dims:
+            When True, prepend a channel axis to axes and coordinate transforms.
         """
         group_keys = zgroup.keys()
 
         for key in chain(group_keys, '/'):
             if isinstance(zgroup[key], zarr.Group):
                 if key!='/':
-                    self.normalize_to_omengff(zgroup[key])
+                    self.normalize_to_omengff(zgroup[key], expand_dims)
                 if 'scales' in zgroup[key].attrs.asdict():
-                    zattrs = self.apply_ome_template(zgroup[key])
+                    zattrs = self.apply_ome_template(zgroup[key], expand_dims)
                     unsorted_datasets = []
                     for arr in self._iter_arrays(zgroup[key]):
-                        unsorted_datasets.append(self.ome_dataset_metadata(arr[1], zgroup[key]))
+                        unsorted_datasets.append(self.ome_dataset_metadata(arr[1], zgroup[key], expand_dims))
 
                     #1.apply natural sort to organize datasets metadata array for different resolution degrees (s0 -> s10)
                     #2.add datasets metadata to the omengff template
@@ -251,7 +253,8 @@ class N5Group(Volume):
                 yield from N5Group._iter_arrays(node)
 
     @staticmethod
-    def ome_dataset_metadata(n5arr: zarr.Array, group: zarr.Group) -> dict:
+    def ome_dataset_metadata(n5arr: zarr.Array, group: zarr.Group,
+                             expand_dims: bool = False) -> dict:
         """Build one OME-NGFF dataset metadata entry from an N5 array.
 
         Parameters
@@ -260,23 +263,27 @@ class N5Group(Volume):
             Source N5 array with a "transform" attribute.
         group:
             Parent group used to compute the relative path.
+        expand_dims:
+            When True, prepend 1.0/0.0 to the scale/translation vectors.
 
         Returns
         -------
         dict
             A single entry suitable for the "datasets" list in multiscales.
         """
-
         arr_attrs_n5 = n5arr.attrs['transform']
-        dataset_meta =  {
-                        "path": os.path.relpath(n5arr.path, group.path),
-                        "coordinateTransformations": [{
-                            'type': 'scale',
-                            'scale': arr_attrs_n5['scale']},{
-                            'type': 'translation',
-                            'translation' : arr_attrs_n5['translate']
-                        }]}
-
+        scale = arr_attrs_n5['scale']
+        translate = arr_attrs_n5['translate']
+        if expand_dims:
+            scale = [1.0] + list(scale)
+            translate = [0.0] + list(translate)
+        dataset_meta = {
+            "path": os.path.relpath(n5arr.path, group.path),
+            "coordinateTransformations": [
+                {'type': 'scale', 'scale': scale},
+                {'type': 'translation', 'translation': translate},
+            ],
+        }
         return dataset_meta
 
     def write_to_zarr(

--- a/src/zarrify/formats/n5.py
+++ b/src/zarrify/formats/n5.py
@@ -177,13 +177,16 @@ class N5Group(Volume):
             for k, v in attrs.items():
                 z_arr.attrs[k] = v
 
-    def apply_ome_template(self, zgroup: zarr.Group) -> dict:
+    def apply_ome_template(self, zgroup: zarr.Group, expand_dims: bool = False) -> dict:
         """Build an OME-NGFF v0.4 multiscales attribute dict from N5 group attributes.
 
         Parameters
         ----------
         zgroup:
             Zarr group with N5-style "axes", "units", and "scales" attributes.
+        expand_dims:
+            When True, prepend a channel axis to the axes list and an extra
+            element to the top-level coordinateTransformations.
 
         Returns
         -------
@@ -196,14 +199,16 @@ class N5Group(Volume):
         ureg = pint.UnitRegistry()
         units_list = [str(ureg.Unit(unit)) for unit in zgroup.attrs['units']]
 
+        axes = [{"name": axis, "type": "space", "unit": unit}
+                for (axis, unit) in zip(zgroup.attrs['axes'], units_list)]
+        if expand_dims:
+            axes = [{"name": "c", "type": "channel"}] + axes
+
         #populate .zattrs
-        z_attrs['multiscales'][0]['axes'] = [{"name": axis,
-                                            "type": "space",
-                                            "unit": unit} for (axis, unit) in zip(zgroup.attrs['axes'],
-                                                                                    units_list)]
+        z_attrs['multiscales'][0]['axes'] = axes
         z_attrs['multiscales'][0]['version'] = '0.4'
         z_attrs['multiscales'][0]['name'] = zgroup.name
-        ndim = len(zgroup.attrs['axes'])
+        ndim = len(axes)
         z_attrs['multiscales'][0]['coordinateTransformations'] = [
             {"type": "scale", "scale": [1.0] * ndim},
             {"type": "translation", "translation": [0.0] * ndim},

--- a/src/zarrify/formats/n5.py
+++ b/src/zarrify/formats/n5.py
@@ -293,6 +293,7 @@ class N5Group(Volume):
         chunk_shape: list[int],
         shard_shape: list[int] | None = None,
         codec: dict = zstd_codec(level=6),
+        expand_dims: bool = False,
     ) -> None:
         """Copy all N5 arrays into a zarr3 store via TensorStore.
 
@@ -337,12 +338,14 @@ class N5Group(Volume):
             src_arr = open_ts(src_spec)
             shape = src_arr.shape
             dtype = np.dtype(src_arr.dtype.numpy_dtype)
+            out_shape = (1, *shape) if expand_dims else shape
 
             # trim chunk/shard shapes to array ndim; N5 trees can hold mixed-dimensionality arrays
-            arr_chunk_shape = [min(c, s) for c, s in zip(list(chunk_shape)[-len(shape):], shape)]
+            arr_chunk_shape_base = [min(c, s) for c, s in zip(list(chunk_shape)[-len(shape):], shape)]
+            arr_chunk_shape = ([1] + arr_chunk_shape_base) if expand_dims else arr_chunk_shape_base
             arr_shard_shape = (
                 align_shard_to_chunks(
-                    [min(s, dim) for s, dim in zip(list(shard_shape)[-len(shape):], shape)],
+                    [min(s, dim) for s, dim in zip(list(shard_shape)[-len(out_shape):], out_shape)],
                     arr_chunk_shape,
                 )
                 if shard_shape is not None else None
@@ -353,7 +356,7 @@ class N5Group(Volume):
             dst_spec = zarr3_spec(
                 store_path=dest,
                 array_path=rel_path,
-                shape=shape,
+                shape=out_shape,
                 dtype=dtype,
                 chunk_shape=arr_chunk_shape,
                 shard_shape=arr_shard_shape,
@@ -365,7 +368,7 @@ class N5Group(Volume):
             dest_chunks = dest_arr.chunk_layout.write_chunk.shape
 
             out_slices = slices_from_chunks(
-                normalize_chunks(dest_chunks, shape=shape)
+                normalize_chunks(dest_chunks, shape=out_shape)
             )
             # break the slices up into batches, to make things easier for the dask scheduler
             out_slices_partitioned = tuple(partition_all(100000, out_slices))
@@ -374,7 +377,7 @@ class N5Group(Volume):
                 logging.info(f"{idx + 1} / {len(out_slices_partitioned)}")
                 start = time.time()
                 fut = client.map(
-                    lambda v: save_chunk(src_spec, dst_spec, v, invert=False), part
+                    lambda v: save_chunk(src_spec, dst_spec, v, invert=False, expand_dims=expand_dims), part
                 )
                 logging.info(
                     f"Submitted {len(part)} tasks to the scheduler in {time.time() - start:.2f}s"
@@ -388,7 +391,7 @@ class N5Group(Volume):
         # copy array-level N5 attributes (e.g. transform) then build OME metadata
         self._copy_n5_array_attrs(n5_root_path, dest, n5_array_paths)
         z_root = zarr.open_group(store=z_store, mode='a')
-        self.normalize_to_omengff(z_root)
+        self.normalize_to_omengff(z_root, expand_dims)
 
 
 def save_chunk(
@@ -396,6 +399,7 @@ def save_chunk(
     dst_spec: dict,
     chunk_slice: Tuple[slice, ...],
     invert: bool = False,
+    expand_dims: bool = False,
 ) -> None:
     """Copy one chunk from an N5 array into a zarr3 TensorStore array.
 
@@ -408,16 +412,22 @@ def save_chunk(
     dst_spec:
         TensorStore zarr3 driver spec for the destination array.
     chunk_slice:
-        Slice tuple identifying the chunk region to copy.
+        Slice tuple identifying the chunk region in the destination array.
     invert:
         When True, apply bitwise inversion to the data before writing.
+    expand_dims:
+        When True, strip the leading slice when reading the source (which has
+        no channel dimension) and prepend np.newaxis before writing.
     """
     src = open_ts(src_spec)
-    data = src[chunk_slice].read().result()
+    src_slice = chunk_slice[1:] if expand_dims else chunk_slice
+    data = src[src_slice].read().result()
     # only store data if it is not all 0s
     if (data == 0).all():
         return
     if invert:
         data = np.invert(data)
+    if expand_dims:
+        data = data[np.newaxis]
     dest = open_ts(dst_spec)
     dest[chunk_slice].write(data).result()

--- a/src/zarrify/formats/tiff.py
+++ b/src/zarrify/formats/tiff.py
@@ -69,7 +69,7 @@ class Tiff(Volume):
         self.metadata["translation"] = self.metadata["translation"][-self.ndim:]
         self.metadata["units"] = self.metadata["units"][-self.ndim:]
 
-    def write_to_zarr(self, dst_spec: dict, client: Client) -> None:
+    def write_to_zarr(self, dst_spec: dict, client: Client, expand_dims: bool = False) -> None:
         """Read the TIFF file in slabs and write each slab to a zarr3 array via TensorStore.
 
         Parameters
@@ -79,6 +79,9 @@ class Tiff(Volume):
             by :func:`~zarrify.utils.ts_utils.zarr3_spec`.
         client:
             Dask distributed client used to parallelise slab writes.
+        expand_dims:
+            When True, the destination array has a leading size-1 channel
+            dimension; each slab is written with an extra np.newaxis prepended.
         """
         # TODO: With large shard shapes (e.g. 1024^3) the slab thickness along
         # the slab axis becomes 1024 voxels, potentially exhausting worker memory.
@@ -87,21 +90,25 @@ class Tiff(Volume):
         # can process multiple passes concurrently without holding the full shard
         # in memory at once.
 
-        axes = self.metadata["axes"]
-        slab_axis = axes.index("z") if "z" in axes else 0
+        # axes in metadata are already trimmed to source ndim; use them to find z.
+        src_axes = self.metadata["axes"][1:] if expand_dims else self.metadata["axes"]
+        slab_axis = src_axes.index("z") if "z" in src_axes else 0
 
         dest_arr = open_ts(dst_spec)
+        # dest_chunks includes the leading 1 when expand_dims; strip it for
+        # slice computation which is done against the source shape.
         dest_chunks = list(dest_arr.chunk_layout.write_chunk.shape)
+        src_chunks = dest_chunks[1:] if expand_dims else dest_chunks
 
-        slice_chunks = dest_chunks
+        slice_chunks = src_chunks
         if self.optimize_reads:
             logger.info("Optimizing read chunking...")
             logger.info(f"Output zarr3 write-chunk shape: {dest_chunks}")
             logger.info(f"Input TIFF chunk shape: {self._tiff_chunks}")
-            slice_chunks = dest_chunks[: slab_axis + 1].copy()
+            slice_chunks = src_chunks[: slab_axis + 1].copy()
 
             for dest_chunkdim, tiff_chunkdim, tiff_dim in zip(
-                dest_chunks[slab_axis + 1:],
+                src_chunks[slab_axis + 1:],
                 self._tiff_chunks[slab_axis + 1:],
                 self.shape[slab_axis + 1:],
             ):
@@ -123,7 +130,7 @@ class Tiff(Volume):
 
         start = time.time()
         fut = client.map(
-            lambda v: write_volume_slab(v, dst_spec, src_path), slice_tuples
+            lambda v: write_volume_slab(v, dst_spec, src_path, expand_dims), slice_tuples
         )
         logger.info(
             f"Submitted {len(slice_tuples)} tasks to the scheduler in "
@@ -134,7 +141,8 @@ class Tiff(Volume):
         logger.info(f"Completed {len(slice_tuples)} tasks in {time.time() - start:.2f}s")
 
 
-def write_volume_slab(slice_tuple: tuple, dst_spec: dict, src_path: str) -> None:
+def write_volume_slab(slice_tuple: tuple, dst_spec: dict, src_path: str,
+                      expand_dims: bool = False) -> None:
     """Copy one slab from a TIFF file into a zarr3 TensorStore array.
 
     The TIFF is read directly via tifffile into NumPy (no TensorStore TIFF
@@ -143,12 +151,18 @@ def write_volume_slab(slice_tuple: tuple, dst_spec: dict, src_path: str) -> None
     Parameters
     ----------
     slice_tuple:
-        The slice tuple identifying the slab region to copy.
+        The slice tuple identifying the slab region in the source array.
     dst_spec:
         TensorStore zarr3 spec dict for the destination array.
     src_path:
         Path to the source TIFF file.
+    expand_dims:
+        When True, prepend a size-1 channel dimension to the data before
+        writing and offset the destination slice accordingly.
     """
-    data = imread(src_path)[slice_tuple]
+    data = np.asarray(imread(src_path)[slice_tuple])
     dest_arr = open_ts(dst_spec)
-    dest_arr[slice_tuple].write(np.asarray(data)).result()
+    if expand_dims:
+        dest_arr[(slice(0, 1), *slice_tuple)].write(data[np.newaxis]).result()
+    else:
+        dest_arr[slice_tuple].write(data).result()

--- a/src/zarrify/formats/tiff_stack.py
+++ b/src/zarrify/formats/tiff_stack.py
@@ -1,9 +1,9 @@
+import json
 import logging
 import os
 import time
 from glob import glob
 
-import dask.array as da
 import numpy as np
 from dask.distributed import Client, wait
 from natsort import natsorted
@@ -41,13 +41,13 @@ class TiffStack(Volume):
         super().__init__(src_path, axes, scale, translation, units)
 
         self.stack_list = natsorted(glob(os.path.join(src_path, "*.tif*")))
-        probe_image_store = imread(
-            os.path.join(src_path, self.stack_list[0]), aszarr=True
-        )
-        probe_image_arr = da.from_zarr(probe_image_store)
+        probe_store = imread(os.path.join(src_path, self.stack_list[0]), aszarr=True)
+        tile_meta = json.loads(probe_store[".zarray"])
+        probe_store.close()
 
-        self.dtype = probe_image_arr.dtype
-        self.shape = np.squeeze([len(self.stack_list)] + list(probe_image_arr.shape))
+        self.dtype = np.dtype(tile_meta["dtype"])
+        self.shape = tuple(np.squeeze([len(self.stack_list)] + tile_meta["shape"]))
+        self.ndim = len(self.shape)
 
     def write_to_zarr(self, dst_spec: dict, client: Client) -> None:
         """Assemble tiles into slabs and write each slab to a zarr3 array via TensorStore.

--- a/src/zarrify/formats/tiff_stack.py
+++ b/src/zarrify/formats/tiff_stack.py
@@ -49,7 +49,7 @@ class TiffStack(Volume):
         self.shape = tuple(np.squeeze([len(self.stack_list)] + tile_meta["shape"]))
         self.ndim = len(self.shape)
 
-    def write_to_zarr(self, dst_spec: dict, client: Client) -> None:
+    def write_to_zarr(self, dst_spec: dict, client: Client, expand_dims: bool = False) -> None:
         """Assemble tiles into slabs and write each slab to a zarr3 array via TensorStore.
 
         Parameters
@@ -59,6 +59,9 @@ class TiffStack(Volume):
             by :func:`~zarrify.utils.ts_utils.zarr3_spec`.
         client:
             Dask distributed client used to parallelise slab writes.
+        expand_dims:
+            When True, the destination array has a leading size-1 channel
+            dimension; tiles are written at index [0, chunk_num:...].
         """
         # TODO: With large shard shapes (e.g. 1024^3) the slab thickness along
         # z becomes 1024 voxels, which may exhaust worker memory when assembling
@@ -68,12 +71,13 @@ class TiffStack(Volume):
         # in memory at once.
 
         dest_arr = open_ts(dst_spec)
-        tiff_chunkdim = dest_arr.chunk_layout.write_chunk.shape[0]
-        chunks_list = np.arange(0, dest_arr.shape[0], tiff_chunkdim)
+        z_axis = 1 if expand_dims else 0
+        tiff_chunkdim = dest_arr.chunk_layout.write_chunk.shape[z_axis]
+        chunks_list = np.arange(0, dest_arr.shape[z_axis], tiff_chunkdim)
 
         start = time.time()
         fut = client.map(
-            lambda v: write_tile_slab(v, dst_spec, self.stack_list), chunks_list
+            lambda v: write_tile_slab(v, dst_spec, self.stack_list, expand_dims), chunks_list
         )
         logging.info(
             f"Submitted {len(chunks_list)} tasks to the scheduler in {time.time() - start:.4f}s"
@@ -82,7 +86,8 @@ class TiffStack(Volume):
         logging.info(f"Completed {len(chunks_list)} tasks in {time.time() - start:.2f}s")
 
 
-def write_tile_slab(chunk_num: int, dst_spec: dict, src_volume: list) -> None:
+def write_tile_slab(chunk_num: int, dst_spec: dict, src_volume: list,
+                    expand_dims: bool = False) -> None:
     """Assemble one slab from individual TIFF tiles and write it to a zarr3 TensorStore array.
 
     Parameters
@@ -93,13 +98,16 @@ def write_tile_slab(chunk_num: int, dst_spec: dict, src_volume: list) -> None:
         TensorStore zarr3 spec dict for the destination array.
     src_volume:
         Ordered list of TIFF file paths comprising the full stack.
+    expand_dims:
+        When True, the destination has a leading size-1 channel dimension.
     """
     dest_arr = open_ts(dst_spec)
-    total_z = dest_arr.shape[0]
-    tiff_chunkdim = dest_arr.chunk_layout.write_chunk.shape[0]
+    z_axis = 1 if expand_dims else 0
+    total_z = dest_arr.shape[z_axis]
+    tiff_chunkdim = dest_arr.chunk_layout.write_chunk.shape[z_axis]
 
     actual_thickness = min(tiff_chunkdim, total_z - chunk_num)
-    slab_shape = [actual_thickness] + list(dest_arr.shape[1:])
+    slab_shape = [actual_thickness] + list(dest_arr.shape[z_axis + 1:])
     np_slab = np.empty(slab_shape, dtype=np.dtype(dest_arr.dtype.numpy_dtype))
 
     for slab_index in range(chunk_num, chunk_num + actual_thickness):
@@ -108,4 +116,7 @@ def write_tile_slab(chunk_num: int, dst_spec: dict, src_volume: list) -> None:
         except Exception:
             logging.info(f"Tiff tile with index {slab_index} is not present in tiff stack.")
 
-    dest_arr[chunk_num: chunk_num + actual_thickness].write(np_slab).result()
+    if expand_dims:
+        dest_arr[0, chunk_num: chunk_num + actual_thickness].write(np_slab).result()
+    else:
+        dest_arr[chunk_num: chunk_num + actual_thickness].write(np_slab).result()

--- a/src/zarrify/formats/zarr2.py
+++ b/src/zarrify/formats/zarr2.py
@@ -73,6 +73,41 @@ class Zarr2Group(Volume):
             for k, v in attrs.items():
                 dst_arr.attrs[k] = v
 
+    def _update_multiscales_expand_dims(self, dest: str) -> None:
+        """Prepend a channel axis to any OME multiscales metadata in the output store.
+
+        Called after group/array attrs have been copied from the zarr2 source,
+        when expand_dims=True has added a leading size-1 dimension to every array.
+        """
+        dst_store = zarr.storage.LocalStore(dest)
+        dst_root = zarr.open_group(store=dst_store, mode='a')
+        self._patch_group_multiscales(dst_root)
+
+    def _patch_group_multiscales(self, group: zarr.Group) -> None:
+        for key in group.keys():
+            node = group[key]
+            if isinstance(node, zarr.Group):
+                self._patch_group_multiscales(node)
+
+        if 'multiscales' not in group.attrs:
+            return
+        ms = list(group.attrs['multiscales'])
+        for m in ms:
+            if 'axes' in m:
+                m['axes'] = [{'name': 'c', 'type': 'channel'}] + list(m['axes'])
+            for ct in m.get('coordinateTransformations', []):
+                if ct['type'] == 'scale':
+                    ct['scale'] = [1.0] + list(ct['scale'])
+                elif ct['type'] == 'translation':
+                    ct['translation'] = [0.0] + list(ct['translation'])
+            for ds in m.get('datasets', []):
+                for ct in ds.get('coordinateTransformations', []):
+                    if ct['type'] == 'scale':
+                        ct['scale'] = [1.0] + list(ct['scale'])
+                    elif ct['type'] == 'translation':
+                        ct['translation'] = [0.0] + list(ct['translation'])
+        group.attrs['multiscales'] = ms
+
     def write_to_zarr(
         self,
         dest: str,
@@ -80,6 +115,7 @@ class Zarr2Group(Volume):
         chunk_shape: list[int],
         shard_shape: list[int] | None = None,
         codec: dict = zstd_codec(level=6),
+        expand_dims: bool = False,
     ) -> None:
         logging.basicConfig(
             level=logging.INFO,
@@ -101,11 +137,13 @@ class Zarr2Group(Volume):
 
             shape = tuple(zarray_meta['shape'])
             dtype = np.dtype(zarray_meta['dtype'])
+            out_shape = (1, *shape) if expand_dims else shape
 
-            arr_chunk_shape = [min(c, s) for c, s in zip(list(chunk_shape)[-len(shape):], shape)]
+            arr_chunk_shape_base = [min(c, s) for c, s in zip(list(chunk_shape)[-len(shape):], shape)]
+            arr_chunk_shape = ([1] + arr_chunk_shape_base) if expand_dims else arr_chunk_shape_base
             arr_shard_shape = (
                 align_shard_to_chunks(
-                    [min(s, dim) for s, dim in zip(list(shard_shape)[-len(shape):], shape)],
+                    [min(s, dim) for s, dim in zip(list(shard_shape)[-len(out_shape):], out_shape)],
                     arr_chunk_shape,
                 )
                 if shard_shape is not None else None
@@ -117,7 +155,7 @@ class Zarr2Group(Volume):
             dst_spec = zarr3_spec(
                 store_path=dest,
                 array_path=rel_path,
-                shape=shape,
+                shape=out_shape,
                 dtype=dtype,
                 chunk_shape=arr_chunk_shape,
                 shard_shape=arr_shard_shape,
@@ -128,8 +166,8 @@ class Zarr2Group(Volume):
             dest_arr = open_ts(dst_spec)
             dest_chunks = dest_arr.chunk_layout.write_chunk.shape
 
-            logger.info(f"{rel_path}: shape={shape}, dtype={dtype}, chunk={arr_chunk_shape}, shard={arr_shard_shape}")
-            out_slices = slices_from_chunks(normalize_chunks(dest_chunks, shape=shape))
+            logger.info(f"{rel_path}: shape={out_shape}, dtype={dtype}, chunk={arr_chunk_shape}, shard={arr_shard_shape}")
+            out_slices = slices_from_chunks(normalize_chunks(dest_chunks, shape=out_shape))
             out_slices_partitioned = tuple(partition_all(100000, out_slices))
             logger.info(f"{rel_path}: {len(out_slices)} total slices, {len(out_slices_partitioned)} batch(es)")
 
@@ -137,7 +175,7 @@ class Zarr2Group(Volume):
                 logger.info(f"{rel_path}: {idx + 1} / {len(out_slices_partitioned)}")
                 start = time.time()
                 fut = client.map(
-                    lambda v: save_chunk(src_spec, dst_spec, v), part
+                    lambda v: save_chunk(src_spec, dst_spec, v, expand_dims), part
                 )
                 logger.info(f"Submitted {len(part)} tasks in {time.time() - start:.2f}s")
                 wait(fut)
@@ -145,16 +183,20 @@ class Zarr2Group(Volume):
                 logger.info(f"Completed {len(part)} tasks in {time.time() - start:.2f}s")
 
         self._copy_array_attrs(dest, array_paths)
+        if expand_dims:
+            self._update_multiscales_expand_dims(dest)
 
 
 def save_chunk(
     src_spec: dict,
     dst_spec: dict,
     chunk_slice: Tuple[slice, ...],
+    expand_dims: bool = False,
 ) -> None:
     src = open_ts(src_spec)
-    data = src[chunk_slice].read().result()
+    src_slice = chunk_slice[1:] if expand_dims else chunk_slice
+    data = src[src_slice].read().result()
     if (data == 0).all():
         return
     dest = open_ts(dst_spec)
-    dest[chunk_slice].write(data).result()
+    dest[chunk_slice].write(data[np.newaxis] if expand_dims else data).result()

--- a/src/zarrify/to_zarr.py
+++ b/src/zarrify/to_zarr.py
@@ -42,13 +42,13 @@ def init_dataset(src :str,
         ValueError: return value error if the input file format not in the list.
 
     Returns:
-        Union[TiffStack, Tiff, N5Group, Mrc3D]: return a file format object depending on the input file format. 
-        \n All different file formats objects have identical instance methods (write_to_zarr, add_ome_metadata) to emulate API abstraction. 
+        Union[TiffStack, Tiff, N5Group, Mrc3D]: return a file format object depending on the input file format.
+        \n All different file formats objects have identical instance methods (write_to_zarr, add_ome_metadata) to emulate API abstraction.
     """
-    
+
     src_path = Path(src)
     params = (src, axes, scale, translation, units)
-    
+
     ext = src_path.suffix.lower()
 
     if any(part.endswith('.n5') for part in src_path.parts):
@@ -63,7 +63,7 @@ def init_dataset(src :str,
         return Mrc3D(*params)
     elif ext in (".tif", ".tiff"):
         return Tiff(*params, optimize_reads)
-    
+
     raise ValueError(f"Unsupported source type: {src}")
 
 def to_zarr(src : str,
@@ -77,6 +77,7 @@ def to_zarr(src : str,
             translation : list[float] = [0.0,]*4,
             units: list[str] = ['']+['nanometer',]*3,
             optimize_reads : bool = False,
+            expand_dims : bool = False,
             multiscale : bool = False,
             ms_workers: int = None,
             data_origin : str = None,
@@ -99,6 +100,7 @@ def to_zarr(src : str,
         translation (list[float], optional): offset (in physical units). Defaults to [0.0,]*4.
         units (list[str], optional): physical units. Defaults to ['']+['nanometer']*3.
         shard_shape (list[int] | None, optional): outer shard shape for sharded zarr3 arrays.
+        expand_dims (bool, optional): prepend a size-1 channel dimension to the output array.
         codec (str, optional): compression codec name ('zstd', 'gzip', 'blosc'). Defaults to 'zstd'.
         codec_level (int | None, optional): codec compression level. None uses per-codec default.
     """
@@ -112,14 +114,16 @@ def to_zarr(src : str,
     if isinstance(dataset, N5Group):
         logger.info("Detected N5Group — scaling workers and starting write")
         client.cluster.scale(workers)
-        dataset.write_to_zarr(dest, client, zarr_chunks, shard_shape=shard_shape, codec=codec_dict)
+        dataset.write_to_zarr(dest, client, zarr_chunks, shard_shape=shard_shape, codec=codec_dict,
+                              expand_dims=expand_dims)
         client.cluster.scale(0)
         return
 
     if isinstance(dataset, Zarr2Group):
         logger.info("Detected Zarr2Group — scaling workers and starting write")
         client.cluster.scale(workers)
-        dataset.write_to_zarr(str(dest), client, zarr_chunks, shard_shape=shard_shape, codec=codec_dict)
+        dataset.write_to_zarr(str(dest), client, zarr_chunks, shard_shape=shard_shape, codec=codec_dict,
+                              expand_dims=expand_dims)
         client.cluster.scale(0)
         logger.info("Zarr2Group write complete")
         return
@@ -128,16 +132,32 @@ def to_zarr(src : str,
         logger.info(f"Input dataset shape: {dataset.shape}")
         logger.info(f"Input dataset dtype: {dataset.dtype}")
         logger.info(f"Input dataset ndim: {dataset.ndim}")
-        # Reshape chunks and shard to match data dimensionality
+
+        # Tiff trims metadata to source ndim in __init__; TiffStack and MRC do not.
+        # Normalise here so all formats are consistent before the expand step.
+        for key in ('axes', 'units', 'scale', 'translation'):
+            dataset.metadata[key] = list(dataset.metadata[key])[-len(dataset.shape):]
+
+        # When expanding dims, prepend a channel axis to OME metadata so that
+        # add_ome_metadata writes axes/scale/translation/units for ndim+1.
+        if expand_dims:
+            dataset.metadata['axes'] = ['c'] + list(dataset.metadata['axes'])
+            dataset.metadata['units'] = [''] + list(dataset.metadata['units'])
+            dataset.metadata['scale'] = [1.0] + list(dataset.metadata['scale'])
+            dataset.metadata['translation'] = [0.0] + list(dataset.metadata['translation'])
+
+        out_shape = (1, *dataset.shape) if expand_dims else dataset.shape
+
+        # Reshape chunks and shard to match output dimensionality
         logger.info(f"Zarr chunks: {zarr_chunks}")
-        if len(zarr_chunks) != len(dataset.shape):
+        if len(zarr_chunks) != len(out_shape):
             logger.info(f"Reshaping chunks to match data dimensionality")
-            zarr_chunks = dataset.reshape_to_arr_shape(zarr_chunks, dataset.shape)
+            zarr_chunks = dataset.reshape_to_arr_shape(zarr_chunks, out_shape)
             logger.info(f"Reshaped chunks: {zarr_chunks}")
         if shard_shape is not None:
-            shard_shape = list(shard_shape)[-len(dataset.shape):]
+            shard_shape = list(shard_shape)[-len(out_shape):]
             shard_shape = align_shard_to_chunks(
-                [min(s, dim) for s, dim in zip(shard_shape, dataset.shape)],
+                [min(s, dim) for s, dim in zip(shard_shape, out_shape)],
                 zarr_chunks,
             )
             logger.info(f"Aligned shard_shape to {shard_shape}")
@@ -148,14 +168,14 @@ def to_zarr(src : str,
                 ms_workers = workers
             if not data_origin:
                 raise ValueError('Data origin (raw/labels) is not specified')
-            
-            if custom_scale_factors:    
-                if any([int(s0_dim/ sc) > 32 for s0_dim, sc in zip(dataset.shape, custom_scale_factors[-1])]):
+
+            if custom_scale_factors:
+                if any([int(s0_dim/ sc) > 32 for s0_dim, sc in zip(out_shape, custom_scale_factors[-1])]):
                     raise ValueError('Not enough custom scale levels to generate full multiscale pyramid')
 
         # Create output zarr3 array via TensorStore
         full_scale_arr_name = 's0'
-        create_output_array(dest, dataset.shape, dataset.dtype, zarr_chunks,
+        create_output_array(dest, out_shape, dataset.dtype, zarr_chunks,
                             shard_shape=shard_shape, codec=codec_dict, array_path=full_scale_arr_name)
         dest_spec = zarr3_spec(store_path=dest, array_path=full_scale_arr_name)
         logger.info(f"Created output Zarr array at {dest}/{full_scale_arr_name}")
@@ -169,7 +189,7 @@ def to_zarr(src : str,
         client.cluster.scale(workers)
         if shard_shape is not None:
             check_shardslab_fits_in_ram(shard_shape, dataset.dtype, zarr_chunks, client)
-        dataset.write_to_zarr(dest_spec, client)
+        dataset.write_to_zarr(dest_spec, client, expand_dims=expand_dims)
         client.cluster.scale(0)
         logger.info(f"Completed writing all data to Zarr arrays")
 
@@ -187,8 +207,8 @@ def to_zarr(src : str,
                                     custom_scale_factors)
             client.cluster.scale(0)
             logger.info(f"Completed multiscal pyramid creation")
-        
-    
+
+
 
 @click.command("zarrify")
 @click.option(

--- a/src/zarrify/to_zarr.py
+++ b/src/zarrify/to_zarr.py
@@ -286,6 +286,11 @@ def to_zarr(src : str,
     is_flag=True,
     help="Enable optimized image loading using chunk-aligned reads.",
 )
+@click.option(
+    "--expand_dims",
+    is_flag=True,
+    help="Prepend a size-1 channel dimension to the output array, converting (z,y,x) → (1,z,y,x).",
+)
 
 #def cli(src, dest, workers, cluster, zarr_chunks, axes, translation, scale, units, log_dir, extra_directives, optimize_reads):
 def cli(config, **kwargs):
@@ -294,13 +299,13 @@ def cli(config, **kwargs):
         configs = validate_config(config, **kwargs)
     else:
         configs = {k: v for k, v in kwargs.items() if v not in (None, (), [], {})}
-    
+
     # create a dask client to submit tasks
     client = initialize_dask_client(configs['cluster'],
                                     configs.get('log_dir', None),
                                     configs.get('extra_directives', None))
-    
-    # convert src dataset(n5, tiff, mrc) to zarr ome dataset 
+
+    # convert src dataset(n5, tiff, mrc) to zarr ome dataset
     logger.info(configs)
     to_zarr(src=configs['src'],
             dest=configs['dest'],
@@ -313,6 +318,7 @@ def cli(config, **kwargs):
             translation=configs['translation'],
             units=configs['units'],
             optimize_reads=configs['optimize_reads'],
+            expand_dims=configs.get('expand_dims', False),
             multiscale=configs['multiscale'],
             ms_workers=configs['ms_workers'],
             data_origin=configs['data_origin'],
@@ -322,6 +328,6 @@ def cli(config, **kwargs):
             codec=configs.get('codec', 'zstd'),
             codec_level=configs.get('codec_level'),
     )
-    
+
 if __name__ == "__main__":
     cli()

--- a/src/zarrify/utils/pydantic_models.py
+++ b/src/zarrify/utils/pydantic_models.py
@@ -25,7 +25,8 @@ class ZarrifyConfig(BaseModel):
     scale: List[float] = [1.0, 1.0, 1.0, 1.0]
     units: List[str] = ["", "nanometer", "nanometer", "nanometer"]
     optimize_reads: bool = True
-    
+    expand_dims: bool = False
+
     multiscale: bool = False
     ms_workers: int = 100
     data_origin: Literal['raw', 'labels']

--- a/tests/test_expand_dims_and_4d.py
+++ b/tests/test_expand_dims_and_4d.py
@@ -1,0 +1,297 @@
+"""Tests for expand_dims (3D to 4D casting) and native 4D dataset conversion."""
+import json
+
+import mrcfile
+import numpy as np
+import pytest
+import tensorstore as ts
+import tifffile
+import zarr
+
+from zarrify.to_zarr import to_zarr
+from zarrify.utils.dask_utils import initialize_dask_client
+from zarrify.utils.ts_utils import open_ts, zarr3_spec
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def dask_client():
+    return initialize_dask_client("local")
+
+
+def _make_n5(tmp_path, shape, data, chunks=None):
+    """Create a minimal N5 store with OME-style group attributes."""
+    if chunks is None:
+        chunks = shape
+    n5_path = tmp_path / "test.n5"
+    ndim = len(shape)
+    axes = ["c", "z", "y", "x"][-ndim:]
+    units = ["", "nm", "nm", "nm"][-ndim:]
+
+    spec = {
+        "driver": "n5",
+        "kvstore": {"driver": "file", "path": str(n5_path)},
+        "path": "s0",
+        "metadata": {
+            "dataType": np.dtype(data.dtype).name,
+            "dimensions": list(shape),
+            "blockSize": list(chunks),
+            "compression": {"type": "raw"},
+        },
+        "create": True,
+        "open": True,
+    }
+    ts.open(spec).result()[:].write(data).result()
+
+    root_attrs = {
+        "n5": "2.0.0",
+        "axes": axes,
+        "units": units,
+        "scales": [[1.0] * ndim],
+    }
+    (n5_path / "attributes.json").write_text(json.dumps(root_attrs))
+
+    s0_attrs_path = n5_path / "s0" / "attributes.json"
+    s0_attrs = json.loads(s0_attrs_path.read_text()) if s0_attrs_path.exists() else {}
+    s0_attrs["transform"] = {
+        "scale": [1.0] * ndim,
+        "translate": [0.0] * ndim,
+        "units": units,
+        "axes": axes,
+    }
+    s0_attrs_path.write_text(json.dumps(s0_attrs))
+    return n5_path
+
+
+def _make_zarr2(tmp_path, shape, data, chunks=None):
+    """Create a minimal zarr v2 store with OME multiscales attributes."""
+    if chunks is None:
+        chunks = shape
+    ndim = len(shape)
+    axes = ["c", "z", "y", "x"][-ndim:]
+    src_path = tmp_path / "src.zarr"
+
+    spec = {
+        "driver": "zarr",
+        "kvstore": {"driver": "file", "path": str(src_path)},
+        "path": "s0",
+        "metadata": {
+            "dtype": np.dtype(data.dtype).str,
+            "shape": list(shape),
+            "chunks": list(chunks),
+        },
+        "create": True,
+        "open": True,
+    }
+    ts.open(spec).result()[:].write(data).result()
+
+    multiscales = [{
+        "version": "0.4",
+        "axes": [{"name": ax, "type": "space", "unit": "nanometer"} for ax in axes],
+        "datasets": [{
+            "path": "s0",
+            "coordinateTransformations": [
+                {"type": "scale", "scale": [1.0] * ndim},
+                {"type": "translation", "translation": [0.0] * ndim},
+            ],
+        }],
+    }]
+    (src_path / ".zgroup").write_text(json.dumps({"zarr_format": 2}))
+    (src_path / ".zattrs").write_text(json.dumps({"multiscales": multiscales}))
+    return src_path
+
+
+def _make_tiff_stack(tmp_path, slices):
+    """Write a directory of 2D TIFF tiles and return the directory path."""
+    stack_dir = tmp_path / "stack"
+    stack_dir.mkdir()
+    for i, sl in enumerate(slices):
+        tifffile.imwrite(stack_dir / f"slice_{i:04d}.tif", sl)
+    return stack_dir
+
+
+# ---------------------------------------------------------------------------
+# expand_dims: Tiff, TiffStack, MRC
+# ---------------------------------------------------------------------------
+
+def test_expand_dims_tiff(tmp_path, dask_client):
+    shape = (4, 8, 8)
+    data = np.random.randint(0, 200, shape, dtype=np.uint8)
+    src = tmp_path / "vol.tif"
+    tifffile.imwrite(src, data)
+    dest = tmp_path / "out.zarr"
+
+    to_zarr(str(src), str(dest), dask_client, expand_dims=True)
+
+    result = open_ts(zarr3_spec(str(dest), "s0"))[:].read().result()
+    assert result.shape == (1, *shape)
+    assert np.array_equal(result[0], data)
+
+    root = zarr.open_group(zarr.storage.LocalStore(str(dest)), mode="r")
+    ms_axes = root.attrs["multiscales"][0]["axes"]
+    assert len(ms_axes) == 4
+    assert ms_axes[0]["name"] == "c"
+    assert ms_axes[0]["type"] == "channel"
+
+
+def test_expand_dims_tiff_stack(tmp_path, dask_client):
+    n_slices, h, w = 5, 8, 8
+    data = np.random.randint(0, 200, (n_slices, h, w), dtype=np.uint8)
+    stack_dir = _make_tiff_stack(tmp_path, data)
+    dest = tmp_path / "out.zarr"
+
+    to_zarr(str(stack_dir), str(dest), dask_client, expand_dims=True)
+
+    result = open_ts(zarr3_spec(str(dest), "s0"))[:].read().result()
+    assert result.shape == (1, n_slices, h, w)
+    assert np.array_equal(result[0], data)
+
+    root = zarr.open_group(zarr.storage.LocalStore(str(dest)), mode="r")
+    ms_axes = root.attrs["multiscales"][0]["axes"]
+    assert ms_axes[0]["name"] == "c"
+
+
+def test_expand_dims_mrc(tmp_path, dask_client):
+    shape = (4, 8, 8)
+    data = np.random.randint(0, 200, shape, dtype=np.uint8)
+    src = tmp_path / "vol.mrc"
+    with mrcfile.new(src, overwrite=True) as mrc:
+        mrc.set_data(data)
+    dest = tmp_path / "out.zarr"
+
+    to_zarr(str(src), str(dest), dask_client, expand_dims=True)
+
+    result = open_ts(zarr3_spec(str(dest), "s0"))[:].read().result()
+    assert result.shape == (1, *shape)
+    assert np.array_equal(result[0], data)
+
+    root = zarr.open_group(zarr.storage.LocalStore(str(dest)), mode="r")
+    ms_axes = root.attrs["multiscales"][0]["axes"]
+    assert ms_axes[0]["name"] == "c"
+
+
+# ---------------------------------------------------------------------------
+# expand_dims: Zarr2 - data and OME metadata
+# ---------------------------------------------------------------------------
+
+def test_expand_dims_zarr2(tmp_path, dask_client):
+    shape = (4, 8, 8)
+    data = np.random.randint(0, 200, shape, dtype=np.uint8)
+    src = _make_zarr2(tmp_path, shape, data)
+    dest = tmp_path / "out.zarr"
+
+    to_zarr(str(src), str(dest), dask_client, expand_dims=True)
+
+    result = open_ts(zarr3_spec(str(dest), "s0"))[:].read().result()
+    assert result.shape == (1, *shape)
+    assert np.array_equal(result[0], data)
+
+    root = zarr.open_group(zarr.storage.LocalStore(str(dest)), mode="r")
+    ms = root.attrs["multiscales"][0]
+    assert len(ms["axes"]) == 4
+    assert ms["axes"][0]["name"] == "c"
+    scale = ms["datasets"][0]["coordinateTransformations"][0]["scale"]
+    assert len(scale) == 4
+    assert scale[0] == 1.0
+    translation = ms["datasets"][0]["coordinateTransformations"][1]["translation"]
+    assert len(translation) == 4
+    assert translation[0] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# expand_dims: N5 - data and OME metadata
+# ---------------------------------------------------------------------------
+
+def test_expand_dims_n5(tmp_path, dask_client):
+    shape = (4, 8, 8)
+    data = np.random.randint(0, 200, shape, dtype=np.uint8)
+    n5_path = _make_n5(tmp_path, shape, data)
+    dest = tmp_path / "out.zarr"
+
+    to_zarr(str(n5_path), str(dest), dask_client, expand_dims=True)
+
+    result = open_ts(zarr3_spec(str(dest), "s0"))[:].read().result()
+    assert result.shape == (1, *shape)
+    assert np.array_equal(result[0], data)
+
+    root = zarr.open_group(zarr.storage.LocalStore(str(dest)), mode="r")
+    ms = root.attrs["multiscales"][0]
+    assert len(ms["axes"]) == 4
+    assert ms["axes"][0]["name"] == "c"
+    assert ms["axes"][0]["type"] == "channel"
+    scale = ms["datasets"][0]["coordinateTransformations"][0]["scale"]
+    assert len(scale) == 4
+    assert scale[0] == 1.0
+    translation = ms["datasets"][0]["coordinateTransformations"][1]["translation"]
+    assert len(translation) == 4
+    assert translation[0] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Native 4D datasets (no expand_dims)
+# ---------------------------------------------------------------------------
+
+def test_4d_n5(tmp_path, dask_client):
+    shape = (2, 4, 8, 8)
+    data = np.random.randint(0, 200, shape, dtype=np.uint8)
+    n5_path = _make_n5(tmp_path, shape, data)
+    dest = tmp_path / "out.zarr"
+
+    to_zarr(str(n5_path), str(dest), dask_client)
+
+    result = open_ts(zarr3_spec(str(dest), "s0"))[:].read().result()
+    assert result.shape == shape
+    assert np.array_equal(result, data)
+
+    root = zarr.open_group(zarr.storage.LocalStore(str(dest)), mode="r")
+    ms_axes = root.attrs["multiscales"][0]["axes"]
+    assert len(ms_axes) == 4
+
+
+def test_4d_zarr2(tmp_path, dask_client):
+    shape = (2, 4, 8, 8)
+    data = np.random.randint(0, 200, shape, dtype=np.uint8)
+    src = _make_zarr2(tmp_path, shape, data)
+    dest = tmp_path / "out.zarr"
+
+    to_zarr(str(src), str(dest), dask_client)
+
+    result = open_ts(zarr3_spec(str(dest), "s0"))[:].read().result()
+    assert result.shape == shape
+    assert np.array_equal(result, data)
+
+    root = zarr.open_group(zarr.storage.LocalStore(str(dest)), mode="r")
+    ms_axes = root.attrs["multiscales"][0]["axes"]
+    assert len(ms_axes) == 4
+
+
+def test_4d_tiff(tmp_path, dask_client):
+    shape = (2, 4, 8, 8)
+    data = np.random.randint(0, 200, shape, dtype=np.uint8)
+    src = tmp_path / "vol_4d.tif"
+    tifffile.imwrite(src, data)
+    dest = tmp_path / "out.zarr"
+
+    to_zarr(str(src), str(dest), dask_client)
+
+    result = open_ts(zarr3_spec(str(dest), "s0"))[:].read().result()
+    assert result.shape == shape
+    assert np.array_equal(result, data)
+
+
+def test_4d_mrc(tmp_path, dask_client):
+    shape = (2, 4, 8, 8)
+    data = np.random.randint(0, 200, shape, dtype=np.uint8)
+    src = tmp_path / "vol_4d.mrc"
+    with mrcfile.new(src, overwrite=True) as mrc:
+        mrc.set_data(data)
+    dest = tmp_path / "out.zarr"
+
+    to_zarr(str(src), str(dest), dask_client)
+
+    result = open_ts(zarr3_spec(str(dest), "s0"))[:].read().result()
+    assert result.shape == shape
+    assert np.array_equal(result, data)


### PR DESCRIPTION
# Changes
**New feature: `--expand_dims` flag**
Prepends a size-1 channel dimension to the output array, converting `(z,y,x)` → `(1,z,y,x)`. Supported for all input formats: TIFF, TIFF stack, MRC, zarr v2, and N5.

**Bug fixes bundled in**
- `TiffStack.__init__`: replaced `da.from_zarr(ZarrTiffStore)` with direct `.zarray` JSON read — `ZarrTiffStore` is incompatible with zarr v3
- `N5Group.apply_ome_template`: `coordinateTransformations` scale/translation vectors had wrong length for non-3D arrays (ndim was computed before the channel axis was prepended)

# Implementation
Each format's `write_to_zarr` and its worker function (`save_chunk` / `write_tile_slab` / `write_volume_slab`) receives `expand_dims`. The worker reads from the source using `chunk_slice[1:]` (skipping the channel dim absent in the source) and writes `data[np.newaxis]` into the destination.

OME multiscales metadata is updated per format:
- **Tiff/TiffStack/MRC**: channel axis prepended to `axes/scale/translation/units` in `to_zarr` before `add_ome_metadata` is called
- **zarr v2**: post-processing walk (`_patch_group_multiscales`) rewrites the copied multiscales attrs
- **N5**: `expand_dims` threaded through `normalize_to_omengff` → `apply_ome_template` / `ome_dataset_metadata`

# Tests
`tests/test_expand_dims_and_4d.py` - 9 tests
- `test_expand_dims_{tiff,tiff_stack,mrc,zarr2,n5}`: verify output shape is `(1, *src_shape)` and OME axes metadata has a leading channel axis
- `test_4d_{tiff,mrc,zarr2,n5}`: verify native 4D inputs pass through with correct shape and axes
