### PR TITLE
Remove dask array dependency

### DIFF
--- a/src/zarrify/formats/tiff_stack.py
+++ b/src/zarrify/formats/tiff_stack.py
@@ -3,7 +3,6 @@ import os
 import time
 from glob import glob
 
-import dask.array as da
 import numpy as np
 from dask.distributed import Client, wait
 from natsort import natsorted
@@ -41,13 +40,10 @@ class TiffStack(Volume):
         super().__init__(src_path, axes, scale, translation, units)
 
         self.stack_list = natsorted(glob(os.path.join(src_path, "*.tif*")))
-        probe_image_store = imread(
-            os.path.join(src_path, self.stack_list[0]), aszarr=True
-        )
-        probe_image_arr = da.from_zarr(probe_image_store)
-
-        self.dtype = probe_image_arr.dtype
-        self.shape = np.squeeze([len(self.stack_list)] + list(probe_image_arr.shape))
+        probe = imread(self.stack_list[0])
+        self.dtype = probe.dtype
+        self.shape = tuple(np.squeeze([len(self.stack_list)] + list(probe.shape)))
+        self.ndim = len(self.shape)
 
     def write_to_zarr(self, dst_spec: dict, client: Client) -> None:
         """Assemble tiles into slabs and write each slab to a zarr3 array via TensorStore.


### PR DESCRIPTION
:recycle: remove dask array dependency, and rely only on tifffile to read metadata for a tile. 