### PR TITLE
add "dimension_names" attribute to array metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "zarrify"
-version = "0.1.1"
+version = "0.1.2"
 description = "Convert scientific image formats (TIFF, MRC, N5) to OME-Zarr"
 authors = [
     { name = "Yurii Zubov", email = "zubov452@gmail.com" }

--- a/src/zarrify/formats/mrc.py
+++ b/src/zarrify/formats/mrc.py
@@ -41,9 +41,10 @@ class Mrc3D(Volume):
         super().__init__(src_path, axes, scale, translation, units)
 
         self.memmap = mrcfile.mmap(self.src_path, mode="r")
-        self.ndim = self.memmap.data.ndim
-        self.shape = np.squeeze(self.memmap.data.shape)
+        self.shape = tuple(np.squeeze(self.memmap.data.shape).tolist())
+        self.ndim = len(self.shape)
         self.dtype = self.memmap.data.dtype
+        self._validate_metadata_rank(self.ndim)
 
     def write_to_zarr(self, dst_spec: dict, client: Client) -> None:
         """Read the MRC file in chunks and write each chunk to a zarr3 array via TensorStore.

--- a/src/zarrify/formats/n5.py
+++ b/src/zarrify/formats/n5.py
@@ -309,6 +309,15 @@ class N5Group(Volume):
         # input n5 arrays list to convert
         n5_array_paths = self._find_n5_arrays(n5_root_path)
 
+        # Validate every source array's rank against config metadata before any
+        # data is written. Multiscale datasets must have homogeneous rank, so a
+        # mismatch on any array is a fatal config error and should be caught up
+        # front rather than partway through the conversion.
+        for rel_path in n5_array_paths:
+            store_rel_path = os.path.join(self.path, rel_path) if self.path else rel_path
+            src_arr = open_ts(n5_spec(self.store_path, store_rel_path))
+            self._validate_metadata_rank(len(src_arr.shape))
+
         # copy input n5 tree structure to output zarr and add ome-metadata, when N5 metadata is present
         z_store = zarr.storage.LocalStore(dest)
         z_root = zarr.open_group(store=z_store, mode='a')
@@ -321,7 +330,6 @@ class N5Group(Volume):
             shape = src_arr.shape
             dtype = np.dtype(src_arr.dtype.numpy_dtype)
 
-            # trim chunk/shard shapes to array ndim; N5 trees can hold mixed-dimensionality arrays
             arr_chunk_shape = [min(c, s) for c, s in zip(list(chunk_shape)[-len(shape):], shape)]
             arr_shard_shape = (
                 align_shard_to_chunks(
@@ -333,19 +341,7 @@ class N5Group(Volume):
             if arr_shard_shape is not None:
                 check_shardslab_fits_in_ram(arr_shard_shape, dtype, arr_chunk_shape, client)
 
-            # Read axes from the array's parent group attributes.json so the output
-            # array's dimension_names matches the OME multiscales axes.
-            parent_dir = os.path.dirname(os.path.join(self.store_path, rel_path))
-            parent_attrs_path = os.path.join(parent_dir, 'attributes.json')
-            dim_names = None
-            if os.path.exists(parent_attrs_path):
-                try:
-                    with open(parent_attrs_path) as f:
-                        parent_attrs = json.load(f)
-                    if 'axes' in parent_attrs and len(parent_attrs['axes']) == len(shape):
-                        dim_names = list(parent_attrs['axes'])
-                except (json.JSONDecodeError, OSError):
-                    pass
+            dim_names = list(self.metadata["axes"])
 
             dst_spec = zarr3_spec(
                 store_path=dest,

--- a/src/zarrify/formats/n5.py
+++ b/src/zarrify/formats/n5.py
@@ -333,6 +333,20 @@ class N5Group(Volume):
             if arr_shard_shape is not None:
                 check_shardslab_fits_in_ram(arr_shard_shape, dtype, arr_chunk_shape, client)
 
+            # Read axes from the array's parent group attributes.json so the output
+            # array's dimension_names matches the OME multiscales axes.
+            parent_dir = os.path.dirname(os.path.join(self.store_path, rel_path))
+            parent_attrs_path = os.path.join(parent_dir, 'attributes.json')
+            dim_names = None
+            if os.path.exists(parent_attrs_path):
+                try:
+                    with open(parent_attrs_path) as f:
+                        parent_attrs = json.load(f)
+                    if 'axes' in parent_attrs and len(parent_attrs['axes']) == len(shape):
+                        dim_names = list(parent_attrs['axes'])
+                except (json.JSONDecodeError, OSError):
+                    pass
+
             dst_spec = zarr3_spec(
                 store_path=dest,
                 array_path=rel_path,
@@ -341,6 +355,7 @@ class N5Group(Volume):
                 chunk_shape=arr_chunk_shape,
                 shard_shape=arr_shard_shape,
                 codec=codec,
+                dimension_names=dim_names,
                 create=True,
             )
 

--- a/src/zarrify/formats/tiff.py
+++ b/src/zarrify/formats/tiff.py
@@ -63,11 +63,7 @@ class Tiff(Volume):
         self._tiff_chunks = tuple(_meta['chunks'])
         self.optimize_reads = optimize_reads
 
-        # Trim metadata to match actual data dimensionality.
-        self.metadata["axes"] = list(self.metadata["axes"])[-self.ndim:]
-        self.metadata["scale"] = self.metadata["scale"][-self.ndim:]
-        self.metadata["translation"] = self.metadata["translation"][-self.ndim:]
-        self.metadata["units"] = self.metadata["units"][-self.ndim:]
+        self._validate_metadata_rank(self.ndim)
 
     def write_to_zarr(self, dst_spec: dict, client: Client) -> None:
         """Read the TIFF file in slabs and write each slab to a zarr3 array via TensorStore.

--- a/src/zarrify/formats/tiff_stack.py
+++ b/src/zarrify/formats/tiff_stack.py
@@ -44,6 +44,7 @@ class TiffStack(Volume):
         self.dtype = probe.dtype
         self.shape = tuple(np.squeeze([len(self.stack_list)] + list(probe.shape)))
         self.ndim = len(self.shape)
+        self._validate_metadata_rank(self.ndim)
 
     def write_to_zarr(self, dst_spec: dict, client: Client) -> None:
         """Assemble tiles into slabs and write each slab to a zarr3 array via TensorStore.

--- a/src/zarrify/formats/zarr2.py
+++ b/src/zarrify/formats/zarr2.py
@@ -125,6 +125,24 @@ class Zarr2Group(Volume):
             if arr_shard_shape is not None:
                 check_shardslab_fits_in_ram(arr_shard_shape, dtype, arr_chunk_shape, client)
 
+            # Read axes from the parent group's .zattrs multiscales so the output
+            # array's dimension_names matches the OME multiscales axes.
+            parent_dir = os.path.dirname(os.path.join(self.src_path, rel_path))
+            parent_zattrs = os.path.join(parent_dir, '.zattrs')
+            dim_names = None
+            if os.path.exists(parent_zattrs):
+                try:
+                    with open(parent_zattrs) as f:
+                        parent_attrs = json.load(f)
+                    ms = parent_attrs.get('multiscales') or []
+                    if ms and 'axes' in ms[0]:
+                        axes_meta = ms[0]['axes']
+                        names = [a['name'] if isinstance(a, dict) else a for a in axes_meta]
+                        if len(names) == len(shape):
+                            dim_names = names
+                except (json.JSONDecodeError, OSError):
+                    pass
+
             src_spec = zarr2_spec(self.src_path, rel_path)
             dst_spec = zarr3_spec(
                 store_path=dest,
@@ -134,6 +152,7 @@ class Zarr2Group(Volume):
                 chunk_shape=arr_chunk_shape,
                 shard_shape=arr_shard_shape,
                 codec=codec,
+                dimension_names=dim_names,
                 create=True,
             )
 

--- a/src/zarrify/formats/zarr2.py
+++ b/src/zarrify/formats/zarr2.py
@@ -101,6 +101,12 @@ class Zarr2Group(Volume):
         array_paths = self._find_arrays()
         logger.info(f"Found {len(array_paths)} zarr v2 arrays: {array_paths}")
 
+        # Validate every source array's rank against config metadata before any
+        # data is written. Multiscale datasets must have homogeneous rank.
+        for rel_path in array_paths:
+            with open(os.path.join(self.src_path, rel_path, '.zarray')) as f:
+                self._validate_metadata_rank(len(json.load(f)['shape']))
+
         dst_store = zarr.storage.LocalStore(dest)
         dst_root = zarr.open_group(store=dst_store, mode='a')
         self._copy_group_attrs(dst_root)
@@ -125,23 +131,7 @@ class Zarr2Group(Volume):
             if arr_shard_shape is not None:
                 check_shardslab_fits_in_ram(arr_shard_shape, dtype, arr_chunk_shape, client)
 
-            # Read axes from the parent group's .zattrs multiscales so the output
-            # array's dimension_names matches the OME multiscales axes.
-            parent_dir = os.path.dirname(os.path.join(self.src_path, rel_path))
-            parent_zattrs = os.path.join(parent_dir, '.zattrs')
-            dim_names = None
-            if os.path.exists(parent_zattrs):
-                try:
-                    with open(parent_zattrs) as f:
-                        parent_attrs = json.load(f)
-                    ms = parent_attrs.get('multiscales') or []
-                    if ms and 'axes' in ms[0]:
-                        axes_meta = ms[0]['axes']
-                        names = [a['name'] if isinstance(a, dict) else a for a in axes_meta]
-                        if len(names) == len(shape):
-                            dim_names = names
-                except (json.JSONDecodeError, OSError):
-                    pass
+            dim_names = list(self.metadata["axes"])
 
             src_spec = zarr2_spec(self.src_path, rel_path)
             dst_spec = zarr3_spec(

--- a/src/zarrify/to_zarr.py
+++ b/src/zarrify/to_zarr.py
@@ -156,7 +156,8 @@ def to_zarr(src : str,
         # Create output zarr3 array via TensorStore
         full_scale_arr_name = 's0'
         create_output_array(dest, dataset.shape, dataset.dtype, zarr_chunks,
-                            shard_shape=shard_shape, codec=codec_dict, array_path=full_scale_arr_name)
+                            shard_shape=shard_shape, codec=codec_dict, array_path=full_scale_arr_name,
+                            dimension_names=list(dataset.metadata["axes"]))
         dest_spec = zarr3_spec(store_path=dest, array_path=full_scale_arr_name)
         logger.info(f"Created output Zarr array at {dest}/{full_scale_arr_name}")
 

--- a/src/zarrify/utils/ts_utils.py
+++ b/src/zarrify/utils/ts_utils.py
@@ -192,6 +192,15 @@ def zarr3_spec(
     if create:
         if shape is None or dtype is None or chunk_shape is None:
             raise ValueError("shape, dtype, and chunk_shape are required when create=True")
+        if dimension_names is None:
+            raise ValueError(
+                "dimension_names is required when create=True (OME-NGFF 0.5 spec)"
+            )
+        if len(dimension_names) != len(shape):
+            raise ValueError(
+                f"dimension_names length ({len(dimension_names)}) must match "
+                f"shape length ({len(shape)})"
+            )
 
         outer_shape = shard_shape if shard_shape is not None else chunk_shape
         resolved_codec = codec if codec is not None else zstd_codec()
@@ -206,9 +215,8 @@ def zarr3_spec(
             "data_type": np.dtype(dtype).name,
             "codecs": _build_codecs(resolved_codec, chunk_shape if shard_shape is not None else None, checksum),
             "fill_value": 0,
+            "dimension_names": list(dimension_names),
         }
-        if dimension_names is not None:
-            spec["metadata"]["dimension_names"] = list(dimension_names)
 
     return spec
 

--- a/src/zarrify/utils/ts_utils.py
+++ b/src/zarrify/utils/ts_utils.py
@@ -133,6 +133,7 @@ def zarr3_spec(
     shard_shape: list[int] | None = None,
     codec: dict | None = None,
     checksum: bool = True,
+    dimension_names: list[str] | None = None,
     *,
     create: bool = False,
 ) -> dict:
@@ -206,6 +207,8 @@ def zarr3_spec(
             "codecs": _build_codecs(resolved_codec, chunk_shape if shard_shape is not None else None, checksum),
             "fill_value": 0,
         }
+        if dimension_names is not None:
+            spec["metadata"]["dimension_names"] = list(dimension_names)
 
     return spec
 

--- a/src/zarrify/utils/volume.py
+++ b/src/zarrify/utils/volume.py
@@ -224,6 +224,7 @@ class Volume:
                 chunk_shape=resolved_chunk_shape,
                 shard_shape=shard_shape,
                 codec=codec,
+                dimension_names=[a['name'] for a in ms['axes']],
                 create=True,
             )
             dest_arr = open_ts(dst_spec)

--- a/src/zarrify/utils/volume.py
+++ b/src/zarrify/utils/volume.py
@@ -41,6 +41,25 @@ class Volume:
         from itertools import cycle, islice
         return list(islice(cycle(param_arr), len(ref_arr)))
 
+    def _validate_metadata_rank(self, ndim: int) -> None:
+        """Raise if axes/units/scale/translation lengths don't match *ndim*.
+
+        Called by format subclasses once the source's dimensionality is known.
+        Multiscale datasets must have a single rank, so a single config applies
+        to every array in the store.
+        """
+        mismatches = {
+            key: len(self.metadata[key])
+            for key in ("axes", "units", "scale", "translation")
+            if len(self.metadata[key]) != ndim
+        }
+        if mismatches:
+            raise ValueError(
+                f"Source has {ndim} dimensions but config metadata has "
+                f"mismatched lengths: {mismatches}. "
+                f"Pass {ndim}-element axes/units/scale/translation."
+            )
+
     def add_ome_metadata(self, dest: str, full_scale_group_name: str = 's0') -> None:
         """Write OME-NGFF v0.5 multiscales metadata to the zarr store root.
 

--- a/src/zarrify/utils/zarr_utils.py
+++ b/src/zarrify/utils/zarr_utils.py
@@ -12,6 +12,7 @@ def create_output_array(
     codec: dict = zstd_codec(level=6),
     checksum: bool = True,
     array_path: str = "s0",
+    dimension_names: list[str] | None = None,
 ) -> object:
     """Create and open a zarr3 output array via TensorStore.
 
@@ -50,6 +51,7 @@ def create_output_array(
         shard_shape=shard_shape,
         codec=codec,
         checksum=checksum,
+        dimension_names=dimension_names,
         create=True,
     )
     return open_ts(spec)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -102,7 +102,10 @@ def test_n5_to_zarr3_ome_metadata_version(tmp_path, dask_client):
     s0_attrs_path.write_text(json.dumps(s0_attrs))
 
     dest = tmp_path / "test_n5.zarr"
-    to_zarr(str(n5_path), str(dest), dask_client)
+    to_zarr(str(n5_path), str(dest), dask_client,
+            axes=["z", "y", "x"], scale=[1.0, 1.0, 1.0],
+            translation=[0.0, 0.0, 0.0], units=["nm", "nm", "nm"],
+            zarr_chunks=[10, 32, 32])
 
     root = zarr.open_group(zarr.storage.LocalStore(str(dest)), mode="r")
     assert "ome" in root.attrs, "expected 'ome' key on N5 conversion output root"
@@ -162,7 +165,10 @@ def test_zarr2_to_zarr3_upgrades_to_05(tmp_path, dask_client):
     (src / ".zattrs").write_text(json.dumps({"multiscales": multiscales}))
 
     dest = tmp_path / "dst.zarr"
-    to_zarr(str(src), str(dest), dask_client)
+    to_zarr(str(src), str(dest), dask_client,
+            axes=["z", "y", "x"], scale=[1.0, 1.0, 1.0],
+            translation=[0.0, 0.0, 0.0], units=["nanometer", "nanometer", "nanometer"],
+            zarr_chunks=[10, 32, 32])
 
     root = zarr.open_group(zarr.storage.LocalStore(str(dest)), mode="r")
     assert "ome" in root.attrs, "zarr3 output should have 'ome' 0.5 key"

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -112,6 +112,26 @@ def test_n5_to_zarr3_ome_metadata_version(tmp_path, dask_client):
     assert any(d["path"] == "s0" for d in ms["datasets"])
 
 
+def test_tiff_to_zarr3_dimension_names_match_axes(tmp_path, dask_client):
+    """zarr3 array metadata has dimension_names matching multiscales axes."""
+    data = np.random.randint(0, 255, (10, 32, 32), dtype=np.uint8)
+    src = tmp_path / "img.tif"
+    tifffile.imwrite(src, data)
+    dest = tmp_path / "img.zarr"
+
+    axes = ["z", "y", "x"]
+    to_zarr(str(src), str(dest), dask_client,
+            axes=axes, scale=[1.0, 1.0, 1.0],
+            translation=[0.0, 0.0, 0.0], units=["nanometer", "nanometer", "nanometer"],
+            zarr_chunks=[10, 32, 32])
+
+    root = zarr.open_group(zarr.storage.LocalStore(str(dest)), mode="r")
+    s0 = root["s0"]
+    assert list(s0.metadata.dimension_names) == axes
+    ms_axes = [a["name"] for a in root.attrs["ome"]["multiscales"][0]["axes"]]
+    assert list(s0.metadata.dimension_names) == ms_axes
+
+
 def test_zarr2_to_zarr3_upgrades_to_05(tmp_path, dask_client):
     """Converting a zarr2 source with 0.4 metadata produces zarr3 with 0.5."""
     shape = (10, 32, 32)

--- a/tests/test_to_zarr.py
+++ b/tests/test_to_zarr.py
@@ -34,7 +34,7 @@ def create_test_file(tmp_path):
 
 
 FORMATS = ['tif', 'tiff', 'mrc']
-SHAPES = [(40, 50), (1, 30, 50)]  # 2D and 3D
+SHAPES = [(40, 50), (10, 30, 50)]  # 2D and 3D (no size-1 dims to keep MRC squeeze stable)
 
 
 @pytest.mark.parametrize("ext,shape", list(itertools.product(FORMATS, SHAPES)))
@@ -42,8 +42,16 @@ def test_to_zarr(create_test_file, ext, shape):
     src_path, expected_data = create_test_file(ext, shape)
     dest_path = Path(f"{src_path.with_suffix('')}.zarr")
 
+    ndim = len(shape)
+    axes = ['z', 'y', 'x'][-ndim:]
+    units = ['nanometer'] * ndim
+    scale = [1.0] * ndim
+    translation = [0.0] * ndim
+
     dask_client = initialize_dask_client('local')
-    to_zarr(src_path, dest_path, dask_client)
+    to_zarr(src_path, dest_path, dask_client,
+            axes=axes, scale=scale, translation=translation, units=units,
+            zarr_chunks=[64] * ndim)
 
     if src_path.suffix.lstrip('.') in ['tif', 'tiff']:
         src_data = tifffile.imread(src_path)
@@ -120,7 +128,10 @@ def test_n5_to_zarr(tmp_path):
 
     dest_path = tmp_path / "test_n5.zarr"
     dask_client = initialize_dask_client('local')
-    to_zarr(str(n5_path), str(dest_path), dask_client)
+    to_zarr(str(n5_path), str(dest_path), dask_client,
+            axes=['z', 'y', 'x'], scale=[1.0, 1.0, 1.0],
+            translation=[0.0, 0.0, 0.0], units=['nm', 'nm', 'nm'],
+            zarr_chunks=[10, 32, 32])
 
     dest_data = open_ts(zarr3_spec(str(dest_path), 's0'))[:].read().result()
     assert dest_data.shape == data.shape
@@ -158,7 +169,10 @@ def test_zarr2_to_zarr3(tmp_path):
 
     dest_path = tmp_path / "test_dst.zarr"
     dask_client = initialize_dask_client('local')
-    to_zarr(str(src_path), str(dest_path), dask_client)
+    to_zarr(str(src_path), str(dest_path), dask_client,
+            axes=['z', 'y', 'x'], scale=[1.0, 1.0, 1.0],
+            translation=[0.0, 0.0, 0.0], units=['nanometer', 'nanometer', 'nanometer'],
+            zarr_chunks=[10, 32, 32])
 
     dest_data = open_ts(zarr3_spec(str(dest_path), 's0'))[:].read().result()
     assert dest_data.shape == data.shape


### PR DESCRIPTION
## Summary

Adds `dimension_names` to every zarr3 array created by zarrify, as required by the OME-NGFF 0.5 spec, and switches from silent metadata trimming to strict rank validation.

## Changes

### Required `dimension_names`
- `zarr3_spec` now requires `dimension_names` whenever `create=True` and raises if the length doesn't match `shape`. Every array zarrify creates carries the dimension names that match the multiscales axes.

### Per-format wiring
- **TIFF / MRC / TiffStack**: pass `dataset.metadata["axes"]` straight through.
- **N5 / Zarr2**: same, applied per array.
- **Multiscale pyramid**: each pyramid level inherits axes from the s0 multiscales entry.

### Rank validation instead of trimming
Previously, format classes silently trimmed user-supplied `axes/units/scale/translation` to match the source's `ndim`. A user could pass `axes=['c','z','y','x']` for a 3D volume and quietly get `['z','y','x']`. That's gone — now:

- `Volume._validate_metadata_rank(ndim)` raises a clear `ValueError` listing the mismatched field lengths.
- TIFF / MRC / TiffStack call it once at init.
- N5 / zarr2 pre-validate every array's rank in one pass before any writes start, so a mismatch halfway through a multi-array tree never wastes work that was already written. Multiscale datasets must have homogeneous rank, which makes a single config valid for the whole store.

### Tests
- New `test_tiff_to_zarr3_dimension_names_match_axes` checks the s0 array's `dimension_names` equals `root.attrs["ome"]["multiscales"][0]["axes"]`.
- Existing tests updated to pass explicit rank-matching `axes`/`units`/`scale`/`translation`, since the silent trim no longer rescues them.
- Test parametrize shapes changed from `(1, 30, 50)` to `(10, 30, 50)` so MRC's `np.squeeze` doesn't change the array rank.


